### PR TITLE
fix: resolve #8 Docker and docker-compose setup for production deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 # Copy this file to .env and adjust values for your deployment.
 
 # ---- PostgreSQL ----
+POSTGRES_DB=clawforge
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_PORT=5432
@@ -10,7 +11,7 @@ POSTGRES_PORT=5432
 DATABASE_URL=postgresql://postgres:postgres@postgres:5432/clawforge
 JWT_SECRET=clawforge-dev-secret-change-in-production
 CORS_ORIGIN=http://localhost:4200
-PORT=4100
+SERVER_PORT=4100
 HOST=0.0.0.0
 
 # ---- Rate Limiting (#40) ----
@@ -27,4 +28,5 @@ SUPERADMIN_PASSWORD=clawforge
 SUPERADMIN_ORG_NAME=Default
 
 # ---- Admin Console ----
+ADMIN_PORT=4200
 NEXT_PUBLIC_API_URL=http://localhost:4100

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 ```bash
 git clone https://github.com/ClawForgeAI/clawforge.git
 cd clawforge
+cp .env.example .env
 docker compose up --build
 ```
 
@@ -64,6 +65,7 @@ Once running:
 - **Admin Console** — [localhost:4200](http://localhost:4200)
 - **API** — [localhost:4100](http://localhost:4100)
 - **Login** — `admin@clawforge.local` / `clawforge`
+- **One-off seed** — `docker compose run --rm seed`
 
 > For manual setup, SSO configuration, and connecting an OpenClaw gateway, see the [Setup Guide](docs/setup.md).
 

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -2,27 +2,31 @@
 FROM node:22-alpine AS base
 WORKDIR /app
 
-# Install dependencies
 FROM base AS deps
 COPY package.json package-lock.json* ./
 RUN npm install
 
-# Build Next.js (standalone output)
 FROM deps AS build
 ARG NEXT_PUBLIC_API_URL=http://localhost:4100
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 COPY . .
 RUN npm run build
 
-# Production image
-FROM base AS runner
+FROM node:22-alpine AS runner
+WORKDIR /app
 ENV NODE_ENV=production
+ENV PORT=4200
 
-# Next.js standalone output includes everything needed
+RUN addgroup -S clawforge && adduser -S -G clawforge clawforge
+
 COPY --from=build /app/.next/standalone ./
 COPY --from=build /app/.next/static ./.next/static
 COPY --from=build /app/public ./public
+COPY --from=build /app/scripts/docker-entrypoint.sh ./docker-entrypoint.sh
+
+RUN chown -R clawforge:clawforge /app
+USER clawforge
 
 EXPOSE 4200
-ENV PORT=4200
+ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/admin/scripts/docker-entrypoint.sh
+++ b/admin/scripts/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+RUNTIME_API_URL="${NEXT_PUBLIC_API_URL:-http://localhost:4100}"
+
+mkdir -p /app/public
+cat > /app/public/runtime-config.js <<CONFIG
+window.__CLAWFORGE_CONFIG__ = {
+  apiUrl: "${RUNTIME_API_URL}"
+};
+CONFIG
+
+exec "$@"

--- a/admin/src/app/api/health/route.ts
+++ b/admin/src/app/api/health/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export function GET() {
+  return NextResponse.json({ status: "ok" });
+}

--- a/admin/src/app/layout.tsx
+++ b/admin/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Script from "next/script";
 import "./globals.css";
 import { ToastProvider } from "@/components/toast";
 
@@ -11,6 +12,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" data-theme="clawforge">
       <body>
+        <Script src="/runtime-config.js" strategy="beforeInteractive" />
         <ToastProvider>{children}</ToastProvider>
       </body>
     </html>

--- a/admin/src/app/login/page.tsx
+++ b/admin/src/app/login/page.tsx
@@ -4,9 +4,8 @@ import { useState, useEffect, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { setAuth } from "@/lib/auth";
 import { login } from "@/lib/api";
+import { getApiBase } from "@/lib/runtime-config";
 import { motion } from "framer-motion";
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4100";
 
 type AuthMode = { methods: string[] };
 
@@ -30,7 +29,9 @@ function LoginForm() {
   const expired = searchParams.get("expired") === "1";
 
   useEffect(() => {
-    fetch(`${API_BASE}/api/v1/auth/mode`)
+    const apiBase = getApiBase();
+
+    fetch(`${apiBase}/api/v1/auth/mode`)
       .then((res) => res.json())
       .then((data: AuthMode) => setAuthMethods(data.methods ?? []))
       .catch(() => setAuthMethods(["password"]));
@@ -66,7 +67,8 @@ function LoginForm() {
     setLoading(true);
 
     try {
-      const res = await fetch(`${API_BASE}/api/v1/auth/exchange`, {
+      const apiBase = getApiBase();
+      const res = await fetch(`${apiBase}/api/v1/auth/exchange`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -3,8 +3,7 @@
  */
 
 import { clearAuth } from "@/lib/auth";
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4100";
+import { getApiBase } from "@/lib/runtime-config";
 
 type FetchOptions = {
   method?: string;
@@ -21,7 +20,7 @@ async function apiFetch<T>(path: string, opts: FetchOptions = {}): Promise<T> {
     headers.Authorization = `Bearer ${opts.token}`;
   }
 
-  const response = await fetch(`${API_BASE}${path}`, {
+  const response = await fetch(`${getApiBase()}${path}`, {
     method: opts.method ?? "GET",
     headers,
     body: opts.body ? JSON.stringify(opts.body) : undefined,

--- a/admin/src/lib/runtime-config.ts
+++ b/admin/src/lib/runtime-config.ts
@@ -1,0 +1,22 @@
+declare global {
+  interface Window {
+    __CLAWFORGE_CONFIG__?: {
+      apiUrl?: string;
+    };
+  }
+}
+
+function normalizeApiUrl(value?: string) {
+  return value?.trim().replace(/\/$/, "");
+}
+
+export function getApiBase() {
+  if (typeof window !== "undefined") {
+    const runtimeUrl = normalizeApiUrl(window.__CLAWFORGE_CONFIG__?.apiUrl);
+    if (runtimeUrl) {
+      return runtimeUrl;
+    }
+  }
+
+  return normalizeApiUrl(process.env.NEXT_PUBLIC_API_URL) ?? "http://localhost:4100";
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,11 @@
 # ClawForge full-stack: Postgres + Server + Admin Console
 #
 # Usage:
+#   cp .env.example .env
 #   docker compose up --build
+#
+# One-off seed:
+#   docker compose run --rm seed
 #
 # Default credentials (seed):
 #   Email:    admin@clawforge.local
@@ -15,7 +19,7 @@ services:
   postgres:
     image: postgres:17-alpine
     environment:
-      POSTGRES_DB: clawforge
+      POSTGRES_DB: ${POSTGRES_DB:-clawforge}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     ports:
@@ -23,7 +27,7 @@ services:
     volumes:
       - clawforge-pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "postgres", "-d", "clawforge"]
+      test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER:-postgres}", "-d", "${POSTGRES_DB:-clawforge}"]
       interval: 5s
       timeout: 3s
       retries: 5
@@ -37,22 +41,23 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      DATABASE_URL: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/clawforge"
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-clawforge}"
       JWT_SECRET: "${JWT_SECRET:-clawforge-dev-secret-change-in-production}"
       CORS_ORIGIN: "${CORS_ORIGIN:-http://localhost:4200}"
-      PORT: "4100"
+      PORT: "${SERVER_PORT:-4100}"
       HOST: "0.0.0.0"
       RATE_LIMIT_ENABLED: "${RATE_LIMIT_ENABLED:-true}"
       AUDIT_RETENTION_DAYS: "${AUDIT_RETENTION_DAYS:-90}"
       AUDIT_CLEANUP_INTERVAL_HOURS: "${AUDIT_CLEANUP_INTERVAL_HOURS:-24}"
       AUDIT_CLEANUP_BATCH_SIZE: "${AUDIT_CLEANUP_BATCH_SIZE:-10000}"
+      SUPERADMIN_EMAIL: "${SUPERADMIN_EMAIL:-admin@clawforge.local}"
+      SUPERADMIN_PASSWORD: "${SUPERADMIN_PASSWORD:-clawforge}"
+      SUPERADMIN_ORG_NAME: "${SUPERADMIN_ORG_NAME:-Default}"
     ports:
-      - "4100:4100"
-    # Run migrations, seed, then start the server
+      - "${SERVER_PORT:-4100}:4100"
     command: >
       sh -c "
-        npx drizzle-kit migrate &&
-        npx tsx src/db/seed.ts &&
+        ./node_modules/.bin/drizzle-kit migrate &&
         node dist/index.js
       "
     healthcheck:
@@ -63,6 +68,22 @@ services:
       start_period: 30s
     restart: unless-stopped
 
+  seed:
+    build:
+      context: server
+      dockerfile: Dockerfile
+    profiles: ["tools"]
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-clawforge}"
+      SUPERADMIN_EMAIL: "${SUPERADMIN_EMAIL:-admin@clawforge.local}"
+      SUPERADMIN_PASSWORD: "${SUPERADMIN_PASSWORD:-clawforge}"
+      SUPERADMIN_ORG_NAME: "${SUPERADMIN_ORG_NAME:-Default}"
+    command: ["node", "./node_modules/tsx/dist/cli.mjs", "src/db/seed.ts"]
+    restart: "no"
+
   admin:
     build:
       context: admin
@@ -72,8 +93,17 @@ services:
     depends_on:
       server:
         condition: service_healthy
+    environment:
+      NEXT_PUBLIC_API_URL: "${NEXT_PUBLIC_API_URL:-http://server:4100}"
+      PORT: "4200"
     ports:
-      - "4200:4200"
+      - "${ADMIN_PORT:-4200}:4200"
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4200/api/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
     restart: unless-stopped
 
 volumes:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,29 +2,30 @@
 FROM node:22-alpine AS base
 WORKDIR /app
 
-# Install dependencies
 FROM base AS deps
 COPY package.json package-lock.json* ./
 RUN npm install
 
-# Build TypeScript
 FROM deps AS build
 COPY . .
 RUN npm run build
 
-# Production image
-FROM base AS runner
+FROM node:22-alpine AS runner
+WORKDIR /app
 ENV NODE_ENV=production
+
+RUN addgroup -S clawforge && adduser -S -G clawforge clawforge
 
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/package.json ./package.json
-# Drizzle needs the config + migrations at runtime for db:migrate
 COPY --from=build /app/drizzle.config.ts ./drizzle.config.ts
 COPY --from=build /app/src/db/migrations ./src/db/migrations
 COPY --from=build /app/src/db/schema.ts ./src/db/schema.ts
-# Seed script (tsx runs TS directly)
 COPY --from=build /app/src/db/seed.ts ./src/db/seed.ts
+
+RUN chown -R clawforge:clawforge /app
+USER clawforge
 
 EXPOSE 4100
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary
- finish the production Docker setup for issue #8 by hardening both images to run as a non-root user
- make the admin console read its API base URL at container startup instead of baking it permanently at image build time
- add an admin health endpoint and compose healthcheck, plus a dedicated one-off seed service and clearer env templating

## Root cause
The repository already had most of the Docker scaffolding, but a few production-critical pieces were still missing:
- both Docker images still ran as root
- the admin console consumed `NEXT_PUBLIC_API_URL` as a build-time value only, which made runtime deployment reconfiguration awkward
- the admin service had no explicit health probe
- seeding was coupled to the main server startup instead of being exposed as a safer one-off operation

## What changed
- added non-root runtime users to `server/Dockerfile` and `admin/Dockerfile`
- added `admin/scripts/docker-entrypoint.sh` to emit `/runtime-config.js` from runtime env vars before starting Next.js
- added `admin/src/lib/runtime-config.ts` and switched client API calls to use runtime config
- added `admin/src/app/api/health/route.ts` and wired it into compose healthchecks
- updated `docker-compose.yml` to:
  - template `POSTGRES_DB`, `SERVER_PORT`, and `ADMIN_PORT`
  - run migrations on server startup without auto-seeding every boot
  - expose a dedicated `seed` one-off service
  - pass runtime API URL to the admin container
- updated `.env.example` and README usage notes

## Validation
- `pnpm --filter @ClawForgeAI/clawforge-admin build` ✅
- `pnpm --filter @ClawForgeAI/clawforge-server build` ✅
- `docker compose config` ✅
- `pnpm --filter @ClawForgeAI/clawforge-admin test` ⚠️ fails in several existing UI/component tests that appear unrelated to this change set (badge/card/sidebar/dashboard/login expectations)
- Docker image builds were not executed in this environment because the local Docker daemon was unavailable (`Cannot connect to the Docker daemon at unix:///Users/rahular/.docker/run/docker.sock`)

## Issue
Closes #8
