### PR TITLE
fix: resolve #73 Health check endpoint & readiness probes

### DIFF
--- a/server/src/middleware/auth.test.ts
+++ b/server/src/middleware/auth.test.ts
@@ -35,7 +35,21 @@ describe("Auth Middleware", () => {
       const res = await app.inject({ method: "GET", url: "/health" });
 
       expect(res.statusCode).toBe(200);
-      expect(res.json()).toEqual({ status: "ok" });
+      expect(res.json()).toMatchObject({ status: "ok", version: "0.1.0" });
+      expect(res.json().uptime).toBeTypeOf("number");
+    });
+
+    it("allows /ready without auth", async () => {
+      const res = await app.inject({ method: "GET", url: "/ready" });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject({
+        status: "ready",
+        checks: {
+          database: { status: "ok" },
+          migrations: { status: "ok" },
+        },
+      });
     });
 
     it("allows /api/v1/auth/mode without auth", async () => {

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -27,6 +27,7 @@ const PUBLIC_ENDPOINTS = new Set([
   "/api/v1/auth/mode",
   "/api/v1/auth/enroll",
   "/health",
+  "/ready",
   "/health/ready",
 ]);
 

--- a/server/src/server.test.ts
+++ b/server/src/server.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildReadinessResponse } from "./server.js";
+
+describe("buildReadinessResponse", () => {
+  it("returns ready when database, migrations, and configured SSO checks pass", async () => {
+    const sql = vi.fn(async (strings: TemplateStringsArray) => {
+      const query = strings.join(" ");
+
+      if (query.includes("SELECT 1")) {
+        return [{ "?column?": 1 }];
+      }
+
+      if (query.includes("FROM __drizzle_migrations")) {
+        return [{ hash: "0003_skill_version" }];
+      }
+
+      if (query.includes("FROM organizations")) {
+        return [{ sso_config: { issuerUrl: "https://example.okta.com" } }];
+      }
+
+      throw new Error(`Unexpected query: ${query}`);
+    });
+
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ issuer: "https://example.okta.com" }), { status: 200 }));
+
+    const result = await buildReadinessResponse({
+      sql: sql as never,
+      version: "0.1.0",
+      fetchImpl,
+    });
+
+    expect(result.status).toBe("ready");
+    expect(result.version).toBe("0.1.0");
+    expect(result.checks.database.status).toBe("ok");
+    expect(result.checks.migrations).toMatchObject({ status: "ok", version: "0003_skill_version" });
+    expect(result.checks.sso).toMatchObject({ status: "ok", configured: true, provider: "https://example.okta.com" });
+  });
+
+  it("returns not_ready when the database check fails", async () => {
+    const sql = vi.fn(async (strings: TemplateStringsArray) => {
+      const query = strings.join(" ");
+
+      if (query.includes("SELECT 1")) {
+        throw new Error("connect ECONNREFUSED");
+      }
+
+      if (query.includes("FROM __drizzle_migrations")) {
+        return [{ hash: "0003_skill_version" }];
+      }
+
+      if (query.includes("FROM organizations")) {
+        return [];
+      }
+
+      throw new Error(`Unexpected query: ${query}`);
+    });
+
+    const result = await buildReadinessResponse({
+      sql: sql as never,
+      version: "0.1.0",
+      fetchImpl: vi.fn(),
+    });
+
+    expect(result.status).toBe("not_ready");
+    expect(result.checks.database.status).toBe("error");
+    expect(result.checks.database.error).toContain("ECONNREFUSED");
+    expect(result.checks.sso).toMatchObject({ status: "skipped", configured: false });
+  });
+
+  it("returns not_ready when configured SSO discovery fails", async () => {
+    const sql = vi.fn(async (strings: TemplateStringsArray) => {
+      const query = strings.join(" ");
+
+      if (query.includes("SELECT 1")) {
+        return [{ "?column?": 1 }];
+      }
+
+      if (query.includes("FROM __drizzle_migrations")) {
+        return [{ hash: "0003_skill_version" }];
+      }
+
+      if (query.includes("FROM organizations")) {
+        return [{ sso_config: { issuerUrl: "https://example.okta.com" } }];
+      }
+
+      throw new Error(`Unexpected query: ${query}`);
+    });
+
+    const fetchImpl = vi.fn(async () => new Response("unavailable", { status: 503 }));
+
+    const result = await buildReadinessResponse({
+      sql: sql as never,
+      version: "0.1.0",
+      fetchImpl,
+    });
+
+    expect(result.status).toBe("not_ready");
+    expect(result.checks.database.status).toBe("ok");
+    expect(result.checks.migrations.status).toBe("ok");
+    expect(result.checks.sso).toMatchObject({
+      status: "error",
+      configured: true,
+      provider: "https://example.okta.com",
+    });
+    expect(result.checks.sso.error).toContain("HTTP 503");
+  });
+});

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -43,6 +43,144 @@ export type ServerConfig = {
   auditCleanupBatchSize?: number;
 };
 
+export type HealthCheckResult = {
+  status: "ok" | "error" | "skipped";
+  latencyMs: number;
+  error?: string;
+  version?: string;
+  provider?: string;
+  configured?: boolean;
+};
+
+export type ReadinessResponse = {
+  status: "ready" | "not_ready";
+  timestamp: string;
+  version: string;
+  checks: {
+    database: HealthCheckResult;
+    migrations: HealthCheckResult;
+    sso: HealthCheckResult;
+  };
+};
+
+type ReadinessDependencies = {
+  sql: Sql;
+  version: string;
+  fetchImpl?: typeof fetch;
+};
+
+function getVersion(): string {
+  return process.env.npm_package_version ?? "0.1.0";
+}
+
+function getUptimeSeconds(): number {
+  return Math.floor(process.uptime());
+}
+
+export async function buildReadinessResponse({ sql, version, fetchImpl = fetch }: ReadinessDependencies): Promise<ReadinessResponse> {
+  const checks: ReadinessResponse["checks"] = {
+    database: { status: "ok", latencyMs: 0 },
+    migrations: { status: "ok", latencyMs: 0 },
+    sso: { status: "skipped", latencyMs: 0, configured: false },
+  };
+
+  let ready = true;
+
+  const databaseStart = Date.now();
+  try {
+    await sql`SELECT 1`;
+    checks.database = {
+      status: "ok",
+      latencyMs: Date.now() - databaseStart,
+    };
+  } catch (err) {
+    ready = false;
+    checks.database = {
+      status: "error",
+      latencyMs: Date.now() - databaseStart,
+      error: err instanceof Error ? err.message : "Database unreachable",
+    };
+  }
+
+  const migrationsStart = Date.now();
+  try {
+    const rows = await sql<{ hash: string | null }[]>`
+      SELECT hash
+      FROM __drizzle_migrations
+      ORDER BY created_at DESC
+      LIMIT 1
+    `;
+
+    checks.migrations = {
+      status: "ok",
+      latencyMs: Date.now() - migrationsStart,
+      version: rows[0]?.hash ?? "unknown",
+    };
+  } catch (err) {
+    ready = false;
+    checks.migrations = {
+      status: "error",
+      latencyMs: Date.now() - migrationsStart,
+      error: err instanceof Error ? err.message : "Unable to verify migrations",
+    };
+  }
+
+  const ssoStart = Date.now();
+  try {
+    const rows = await sql<{ sso_config: { issuerUrl?: string } | null }[]>`
+      SELECT sso_config
+      FROM organizations
+      WHERE sso_config IS NOT NULL
+      LIMIT 1
+    `;
+
+    const issuerUrl = rows[0]?.sso_config?.issuerUrl;
+    if (!issuerUrl) {
+      checks.sso = {
+        status: "skipped",
+        latencyMs: Date.now() - ssoStart,
+        configured: false,
+      };
+    } else {
+      const discoveryUrl = `${issuerUrl.replace(/\/$/, "")}/.well-known/openid-configuration`;
+      const response = await fetchImpl(discoveryUrl, { signal: AbortSignal.timeout(5000) });
+
+      if (!response.ok) {
+        ready = false;
+        checks.sso = {
+          status: "error",
+          latencyMs: Date.now() - ssoStart,
+          configured: true,
+          provider: issuerUrl,
+          error: `OIDC discovery failed with HTTP ${response.status}`,
+        };
+      } else {
+        checks.sso = {
+          status: "ok",
+          latencyMs: Date.now() - ssoStart,
+          configured: true,
+          provider: issuerUrl,
+        };
+      }
+    }
+  } catch (err) {
+    ready = false;
+    checks.sso = {
+      status: "error",
+      latencyMs: Date.now() - ssoStart,
+      configured: true,
+      error: err instanceof Error ? err.message : "Unable to verify SSO provider",
+    };
+  }
+
+  return {
+    status: ready ? "ready" : "not_ready",
+    timestamp: new Date().toISOString(),
+    version,
+    checks,
+  };
+}
+
 export async function createServer(config: ServerConfig) {
   const app = Fastify({
     logger: true,
@@ -93,40 +231,22 @@ export async function createServer(config: ServerConfig) {
   // Auth middleware
   await registerAuthMiddleware(app);
 
-  // Shallow health check (liveness probe)
-  app.get("/health", async () => ({ status: "ok" }));
+  // Health checks
+  app.get("/health", async () => ({ status: "ok", uptime: getUptimeSeconds(), version: getVersion() }));
 
-  // Deep health check (readiness probe) (#41)
-  const getReadyHealth = async () => {
-    const checks: Record<string, { status: string; latency_ms?: number; error?: string }> = {};
-    let allHealthy = true;
-
-    // Check PostgreSQL connectivity
-    const dbStart = Date.now();
-    try {
-      await sql`SELECT 1`;
-      checks.database = { status: "healthy", latency_ms: Date.now() - dbStart };
-    } catch (err) {
-      allHealthy = false;
-      checks.database = {
-        status: "unhealthy",
-        latency_ms: Date.now() - dbStart,
-        error: err instanceof Error ? err.message : "Database unreachable",
-      };
-    }
-
-    const body = {
-      status: allHealthy ? "healthy" : "unhealthy",
-      timestamp: new Date().toISOString(),
-      version: process.env.npm_package_version ?? "0.1.0",
-      checks,
-    };
-
-    return { statusCode: allHealthy ? 200 : 503, body };
+  const sendReadiness = async () => {
+    const body = await buildReadinessResponse({ sql, version: getVersion() });
+    return { statusCode: body.status === "ready" ? 200 : 503, body };
   };
 
+  app.get("/ready", async (_request, reply) => {
+    const { statusCode, body } = await sendReadiness();
+    return reply.code(statusCode).send(body);
+  });
+
+  // Backward-compatible alias.
   app.get("/health/ready", async (_request, reply) => {
-    const { statusCode, body } = await getReadyHealth();
+    const { statusCode, body } = await sendReadiness();
     return reply.code(statusCode).send(body);
   });
 

--- a/server/src/test/helpers.ts
+++ b/server/src/test/helpers.ts
@@ -172,8 +172,27 @@ export async function createTestApp(mockDb?: MockDb): Promise<FastifyInstance> {
   app.decorate("db", db as unknown as FastifyInstance["db"]);
 
   // Health check
-  app.get("/health", async () => ({ status: "ok" }));
-  app.get("/health/ready", async () => ({ status: "healthy" }));
+  app.get("/health", async () => ({ status: "ok", uptime: 1, version: "0.1.0" }));
+  app.get("/ready", async () => ({
+    status: "ready",
+    version: "0.1.0",
+    timestamp: new Date().toISOString(),
+    checks: {
+      database: { status: "ok", latencyMs: 1 },
+      migrations: { status: "ok", latencyMs: 1, version: "test" },
+      sso: { status: "skipped", latencyMs: 0, configured: false },
+    },
+  }));
+  app.get("/health/ready", async () => ({
+    status: "ready",
+    version: "0.1.0",
+    timestamp: new Date().toISOString(),
+    checks: {
+      database: { status: "ok", latencyMs: 1 },
+      migrations: { status: "ok", latencyMs: 1, version: "test" },
+      sso: { status: "skipped", latencyMs: 0, configured: false },
+    },
+  }));
 
   // Auth middleware
   await registerAuthMiddleware(app);


### PR DESCRIPTION
## Summary

The server already had a shallow `/health` endpoint and a partial `/health/ready` probe, but it did not match the issue requirements. Liveness did not expose uptime/version, there was no `/ready` endpoint, and readiness only checked database connectivity.

## Root cause

Health checking had been added incrementally, so the implementation covered only a minimal DB probe and kept the richer production-readiness checks out of the server surface.

## What changed

- expanded `GET /health` to return `status`, `uptime`, and `version`
- added `GET /ready` as the primary readiness endpoint
- kept `GET /health/ready` as a backward-compatible alias
- added readiness checks for:
  - database connectivity
  - latest Drizzle migration visibility from `__drizzle_migrations`
  - configured SSO/OIDC discovery reachability
- returned per-check status and latency in the readiness response
- added focused tests for readiness behavior plus auth bypass coverage for `/ready`

## Validation

- `cd server && npm test`
- `cd server && npm run build`

Fixes #73