### PR TITLE
feat: DLP rules for tool calls and anomaly detection alerts

### DIFF
--- a/admin/src/components/sidebar.tsx
+++ b/admin/src/components/sidebar.tsx
@@ -27,6 +27,7 @@ const NAV_SECTIONS = [
       { href: "/users", label: "Users", icon: UsersIcon },
       { href: "/enrollment", label: "Enrollment", icon: KeyIcon },
       { href: "/audit", label: "Audit Logs", icon: AuditIcon },
+      { href: "/alerts", label: "Alerts", icon: AlertIcon },
     ],
   },
   {

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -271,7 +271,7 @@ export function queryAudit(orgId: string, token: string, params?: AuditQueryFilt
 
 export async function exportAudit(orgId: string, token: string, format: "csv" | "json", params?: AuditQueryFilters) {
   const searchParams = new URLSearchParams({ ...(params ?? {}), format });
-  const response = await fetch(`${API_BASE}/api/v1/audit/${orgId}/export?${searchParams.toString()}`, {
+  const response = await fetch(`${getApiBase()}/api/v1/audit/${orgId}/export?${searchParams.toString()}`, {
     method: "GET",
     headers: {
       Authorization: `Bearer ${token}`,
@@ -549,4 +549,109 @@ export function getRoles(orgId: string, token: string) {
 
 export function getPermissions(orgId: string, token: string) {
   return apiFetch<{ permissions: Permission[] }>(`/api/v1/roles/${orgId}/permissions`, { token });
+}
+
+// --- DLP (#66) ---
+
+export type DlpRule = {
+  name: string;
+  pattern: string;
+  action: "block" | "warn" | "log";
+  severity: "critical" | "high" | "medium" | "info";
+  category?: string;
+  enabled?: boolean;
+  message?: string;
+};
+
+export function getBuiltinDlpRules(token: string) {
+  return apiFetch<{ rules: DlpRule[]; categories: string[] }>("/api/v1/policies/dlp/builtin-rules", { token });
+}
+
+// --- Alerts (#51) ---
+
+export type AlertRule = {
+  id: string;
+  name: string;
+  description?: string;
+  ruleType: string;
+  enabled: boolean;
+  config: Record<string, unknown>;
+  severity: string;
+  webhookUrl?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type Alert = {
+  id: string;
+  ruleId: string;
+  userId?: string;
+  severity: string;
+  status: "open" | "acknowledged" | "resolved";
+  title: string;
+  details?: Record<string, unknown>;
+  relatedEventIds?: string[];
+  acknowledgedBy?: string;
+  acknowledgedAt?: string;
+  resolvedBy?: string;
+  resolvedAt?: string;
+  createdAt: string;
+};
+
+export type AlertStats = {
+  total: number;
+  open: number;
+  acknowledged: number;
+  resolved: number;
+  critical: number;
+  high: number;
+};
+
+export function getAlertRules(orgId: string, token: string) {
+  return apiFetch<{ rules: AlertRule[] }>(`/api/v1/alerts/${orgId}/rules`, { token });
+}
+
+export function createAlertRule(
+  orgId: string,
+  token: string,
+  body: {
+    name: string;
+    description?: string;
+    ruleType: string;
+    config: Record<string, unknown>;
+    severity?: string;
+    webhookUrl?: string;
+    enabled?: boolean;
+  },
+) {
+  return apiFetch<AlertRule>(`/api/v1/alerts/${orgId}/rules`, { method: "POST", token, body });
+}
+
+export function updateAlertRule(orgId: string, ruleId: string, token: string, body: Record<string, unknown>) {
+  return apiFetch<AlertRule>(`/api/v1/alerts/${orgId}/rules/${ruleId}`, { method: "PUT", token, body });
+}
+
+export function deleteAlertRule(orgId: string, ruleId: string, token: string) {
+  return apiFetch<{ success: boolean }>(`/api/v1/alerts/${orgId}/rules/${ruleId}`, { method: "DELETE", token });
+}
+
+export function getAlerts(orgId: string, token: string, params?: Record<string, string>) {
+  const qs = params ? "?" + new URLSearchParams(params).toString() : "";
+  return apiFetch<{ alerts: Alert[] }>(`/api/v1/alerts/${orgId}${qs}`, { token });
+}
+
+export function getAlertStats(orgId: string, token: string) {
+  return apiFetch<AlertStats>(`/api/v1/alerts/${orgId}/stats`, { token });
+}
+
+export function acknowledgeAlert(orgId: string, alertId: string, token: string) {
+  return apiFetch<Alert>(`/api/v1/alerts/${orgId}/${alertId}/acknowledge`, { method: "PUT", token });
+}
+
+export function resolveAlert(orgId: string, alertId: string, token: string) {
+  return apiFetch<Alert>(`/api/v1/alerts/${orgId}/${alertId}/resolve`, { method: "PUT", token });
+}
+
+export function evaluateAlertRules(orgId: string, token: string) {
+  return apiFetch<{ alertsCreated: number }>(`/api/v1/alerts/${orgId}/evaluate`, { method: "POST", token });
 }

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -78,6 +78,17 @@ export const policies = pgTable(
     auditLevel: text("audit_level", { enum: ["full", "metadata", "off"] })
       .notNull()
       .default("metadata"),
+    dlpConfig: jsonb("dlp_config").$type<{
+      rules: Array<{
+        name: string;
+        pattern: string;
+        action: "block" | "warn" | "log";
+        severity: "critical" | "high" | "medium" | "info";
+        category?: string;
+        enabled?: boolean;
+        message?: string;
+      }>;
+    }>(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [index("policies_org_id_idx").on(table.orgId)],
@@ -331,56 +342,72 @@ export const rolePermissions = pgTable(
 );
 
 // ---------------------------------------------------------------------------
-// Permissions (#61)
+// Alert Rules (#51)
 // ---------------------------------------------------------------------------
 
-export const permissions = pgTable(
-  "permissions",
+export const alertRules = pgTable(
+  "alert_rules",
   {
     id: uuid("id").primaryKey().defaultRandom(),
+    orgId: uuid("org_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
     name: text("name").notNull(),
     description: text("description"),
-    resource: text("resource").notNull(),
-    action: text("action").notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-  },
-  (table) => [
-    uniqueIndex("permissions_name_idx").on(table.name),
-  ],
-);
-
-// ---------------------------------------------------------------------------
-// Roles (#61)
-// ---------------------------------------------------------------------------
-
-export const roles = pgTable(
-  "roles",
-  {
-    id: uuid("id").primaryKey().defaultRandom(),
-    orgId: uuid("org_id").references(() => organizations.id, { onDelete: "cascade" }),
-    name: text("name").notNull(),
-    description: text("description"),
-    isBuiltIn: boolean("is_built_in").notNull().default(false),
+    ruleType: text("rule_type", {
+      enum: [
+        "denied_tool_burst",
+        "dlp_violation_burst",
+        "off_hours_activity",
+        "sensitive_tool_access",
+        "session_anomaly",
+        "blocked_tool_persistence",
+      ],
+    }).notNull(),
+    enabled: boolean("enabled").notNull().default(true),
+    config: jsonb("config").$type<Record<string, unknown>>().notNull(),
+    severity: text("severity", { enum: ["critical", "high", "medium", "low"] })
+      .notNull()
+      .default("medium"),
+    webhookUrl: text("webhook_url"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [
-    uniqueIndex("roles_org_name_idx").on(table.orgId, table.name),
-  ],
+  (table) => [index("alert_rules_org_idx").on(table.orgId)],
 );
 
-export const rolePermissions = pgTable(
-  "role_permissions",
+// ---------------------------------------------------------------------------
+// Alerts (#51)
+// ---------------------------------------------------------------------------
+
+export const alerts = pgTable(
+  "alerts",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    roleId: uuid("role_id")
+    orgId: uuid("org_id")
       .notNull()
-      .references(() => roles.id, { onDelete: "cascade" }),
-    permissionId: uuid("permission_id")
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    ruleId: uuid("rule_id")
       .notNull()
-      .references(() => permissions.id, { onDelete: "cascade" }),
+      .references(() => alertRules.id, { onDelete: "cascade" }),
+    userId: uuid("user_id"),
+    severity: text("severity", { enum: ["critical", "high", "medium", "low"] })
+      .notNull()
+      .default("medium"),
+    status: text("status", { enum: ["open", "acknowledged", "resolved"] })
+      .notNull()
+      .default("open"),
+    title: text("title").notNull(),
+    details: jsonb("details").$type<Record<string, unknown>>(),
+    relatedEventIds: jsonb("related_event_ids").$type<string[]>(),
+    acknowledgedBy: uuid("acknowledged_by").references(() => users.id),
+    acknowledgedAt: timestamp("acknowledged_at", { withTimezone: true }),
+    resolvedBy: uuid("resolved_by").references(() => users.id),
+    resolvedAt: timestamp("resolved_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    uniqueIndex("role_permissions_role_perm_idx").on(table.roleId, table.permissionId),
+    index("alerts_org_status_idx").on(table.orgId, table.status),
+    index("alerts_org_ts_idx").on(table.orgId, table.createdAt),
   ],
 );

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -23,6 +23,7 @@ import { organizationRoutes } from "./routes/organizations.js";
 import { eventRoutes } from "./routes/events.js";
 import { apiKeyRoutes } from "./routes/api-keys.js";
 import { roleRoutes } from "./routes/roles.js";
+import { alertRoutes } from "./routes/alerts.js";
 import { startAuditRetentionJob, stopAuditRetentionJob } from "./services/audit-retention.js";
 
 // ---------------------------------------------------------------------------
@@ -358,6 +359,7 @@ export async function createServer(config: ServerConfig) {
   await app.register(eventRoutes);
   await app.register(apiKeyRoutes);
   await app.register(roleRoutes);
+  await app.register(alertRoutes);
 
   // Start audit retention cleanup job (#39)
   if (config.auditRetentionDays && config.auditRetentionDays > 0) {

--- a/server/src/services/policy-service.ts
+++ b/server/src/services/policy-service.ts
@@ -9,6 +9,16 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { policies, approvedSkills, policyAssignments } from "../db/schema.js";
 import type * as schema from "../db/schema.js";
 
+export type DlpRuleConfig = {
+  name: string;
+  pattern: string;
+  action: "block" | "warn" | "log";
+  severity: "critical" | "high" | "medium" | "info";
+  category?: string;
+  enabled?: boolean;
+  message?: string;
+};
+
 export type EffectivePolicy = {
   version: number;
   tools: {
@@ -25,6 +35,7 @@ export type EffectivePolicy = {
     message?: string;
   };
   auditLevel: "full" | "metadata" | "off";
+  dlpRules?: DlpRuleConfig[];
 };
 
 export class PolicyService {
@@ -116,6 +127,7 @@ export class PolicyService {
         message: policy.killSwitchMessage ?? undefined,
       },
       auditLevel: policy.auditLevel as "full" | "metadata" | "off",
+      dlpRules: policy.dlpConfig?.rules,
     };
   }
 
@@ -164,11 +176,16 @@ export class PolicyService {
         approved: Array<{ name: string; key: string; scope: "org" | "self" }>;
       };
       auditLevel?: "full" | "metadata" | "off";
+      dlpConfig?: { rules: DlpRuleConfig[] };
     },
   ) {
     // If setting as default, unset other defaults
     if (data.isDefault) {
       await this.db.update(policies).set({ isDefault: false }).where(eq(policies.orgId, orgId));
+    }
+
+    if (data.dlpConfig) {
+      PolicyService.validateDlpRules(data.dlpConfig.rules);
     }
 
     const [created] = await this.db
@@ -180,6 +197,7 @@ export class PolicyService {
         toolsConfig: data.toolsConfig,
         skillsConfig: data.skillsConfig,
         auditLevel: data.auditLevel ?? "metadata",
+        dlpConfig: data.dlpConfig,
       })
       .returning();
     return created;
@@ -201,6 +219,7 @@ export class PolicyService {
         toolsConfig: source.toolsConfig,
         skillsConfig: source.skillsConfig,
         auditLevel: source.auditLevel,
+        dlpConfig: source.dlpConfig,
       })
       .returning();
     return cloned;
@@ -215,8 +234,13 @@ export class PolicyService {
         approved: Array<{ name: string; key: string; scope: "org" | "self" }>;
       };
       auditLevel?: "full" | "metadata" | "off";
+      dlpConfig?: { rules: DlpRuleConfig[] };
     },
   ) {
+    if (data.dlpConfig) {
+      PolicyService.validateDlpRules(data.dlpConfig.rules);
+    }
+
     const existing = await this.getOrgPolicy(orgId);
 
     if (existing) {
@@ -226,6 +250,7 @@ export class PolicyService {
           toolsConfig: data.toolsConfig ?? existing.toolsConfig,
           skillsConfig: data.skillsConfig ?? existing.skillsConfig,
           auditLevel: data.auditLevel ?? existing.auditLevel,
+          dlpConfig: data.dlpConfig ?? existing.dlpConfig,
           version: existing.version + 1,
           updatedAt: new Date(),
         })
@@ -243,6 +268,7 @@ export class PolicyService {
         toolsConfig: data.toolsConfig,
         skillsConfig: data.skillsConfig,
         auditLevel: data.auditLevel ?? "metadata",
+        dlpConfig: data.dlpConfig,
       })
       .returning();
     return created;
@@ -325,5 +351,17 @@ export class PolicyService {
    */
   async removePolicyAssignment(assignmentId: string) {
     await this.db.delete(policyAssignments).where(eq(policyAssignments.id, assignmentId));
+  }
+
+  static validateDlpRules(rules: DlpRuleConfig[]): void {
+    for (const rule of rules) {
+      try {
+        new RegExp(rule.pattern);
+      } catch (err) {
+        throw new Error(
+          `Invalid regex pattern in DLP rule "${rule.name}": ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Implements two related features for enterprise security governance:

### DLP (Data Loss Prevention) — #66
- **Policy extension**: Added `dlpConfig` JSONB column to policies table with configurable rules array (name, regex pattern, action, severity, category)
- **Server-side validation**: Regex pattern validation on save to prevent broken rules from blocking all tool calls
- **Built-in rule library**: API endpoint (`GET /api/v1/policies/dlp/builtin-rules`) serving curated templates for PCI (credit cards), PII (SSN, email, phone), and Secrets (AWS keys, API tokens, private keys, GitHub PATs)
- **Plugin-side scanning**: DLP scanner (`plugin/src/dlp/dlp-scanner.ts`) evaluates rules against tool call arguments with:
  - Pre-compiled regex cache for performance
  - ReDoS protection via field length limits
  - Automatic redaction of matched sensitive data in audit logs
  - Three actions: `block` (prevent tool call), `warn` (allow + audit), `log` (allow + record)
- **Tool enforcer integration**: DLP scan runs after allow/deny list checks in the `before_tool_call` hook
- **Audit events**: New `dlp_violation` event type with redacted violation context

### Anomaly Detection Alerts — #51
- **Database schema**: `alert_rules` and `alerts` tables with full lifecycle (open → acknowledged → resolved)
- **Alert service**: Rule evaluation engine with 3 configurable detection rules:
  - `denied_tool_burst`: >N denied tool calls in M minutes per user
  - `dlp_violation_burst`: >N DLP violations in M minutes per user
  - `off_hours_activity`: Tool calls outside configured business hours
- **API routes**: Full CRUD for alert rules, alert listing/filtering, acknowledge/resolve lifecycle, manual rule evaluation trigger
- **Webhook delivery**: POST notifications to configured URLs when alerts fire
- **Admin console**: Alerts page with stats dashboard, filterable alert list, rule management UI

### Design Improvements Over Original Proposals
- **ReDoS protection**: Regex patterns are pre-compiled and cached; field length capped at 100K chars
- **Redaction**: Matched sensitive data replaced with `***` in audit logs — the audit log itself never contains raw PII
- **Pattern validation**: Server validates regex patterns before saving to prevent invalid rules from breaking enforcement
- **Deduplication**: Alert engine skips creating duplicate open alerts for the same user/rule

## Test plan
- [x] Plugin tests pass (145 tests including DLP scanner and tool enforcer DLP integration)
- [x] Server builds clean (TypeScript compilation)
- [x] Server tests pass (146 tests)
- [ ] Manual: Create DLP rules via admin policy editor, verify tool calls with sensitive data are blocked
- [ ] Manual: Create alert rules, trigger rule evaluation, verify alerts appear in admin console
- [ ] Manual: Test alert lifecycle (acknowledge, resolve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)