### PR TITLE
feat: instance grouping & tagging (issue #64)

### DIFF
--- a/admin/src/app/audit/page.tsx
+++ b/admin/src/app/audit/page.tsx
@@ -31,6 +31,8 @@ export default function AuditPage() {
   const [filterType, setFilterType] = useState("");
   const [filterTool, setFilterTool] = useState("");
   const [filterOutcome, setFilterOutcome] = useState("");
+  const [filterTag, setFilterTag] = useState("");
+  const [filterGroup, setFilterGroup] = useState("");
   const [filterFrom, setFilterFrom] = useState("");
   const [filterTo, setFilterTo] = useState("");
 
@@ -40,10 +42,12 @@ export default function AuditPage() {
     if (filterType) params.eventType = filterType;
     if (filterTool) params.toolName = filterTool;
     if (filterOutcome) params.outcome = filterOutcome;
+    if (filterTag) params.tag = filterTag;
+    if (filterGroup) params.group = filterGroup;
     if (filterFrom) params.from = filterFrom;
     if (filterTo) params.to = filterTo;
     return params;
-  }, [filterUser, filterType, filterTool, filterOutcome, filterFrom, filterTo]);
+  }, [filterUser, filterType, filterTool, filterOutcome, filterTag, filterGroup, filterFrom, filterTo]);
 
   const loadEvents = useCallback(async () => {
     const auth = getAuth();
@@ -184,7 +188,7 @@ export default function AuditPage() {
         {/* Filters */}
         <Card className="mb-6">
           <CardTitle>Filters</CardTitle>
-          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-8 gap-3">
             <input
               value={filterUser}
               onChange={(e) => setFilterUser(e.target.value)}
@@ -214,6 +218,18 @@ export default function AuditPage() {
               <option value="blocked">Blocked</option>
               <option value="error">Error</option>
             </select>
+            <input
+              value={filterTag}
+              onChange={(e) => setFilterTag(e.target.value)}
+              placeholder="Instance tag"
+              className="input input-bordered input-sm w-full"
+            />
+            <input
+              value={filterGroup}
+              onChange={(e) => setFilterGroup(e.target.value)}
+              placeholder="Instance group"
+              className="input input-bordered input-sm w-full"
+            />
             <input
               type="date"
               value={filterFrom}

--- a/admin/src/app/dashboard/clients/page.tsx
+++ b/admin/src/app/dashboard/clients/page.tsx
@@ -8,15 +8,18 @@ import { Card, StatCard } from "@/components/card";
 import { Badge } from "@/components/badge";
 import { StatSkeleton, TableSkeleton } from "@/components/skeleton";
 import { getAuth } from "@/lib/auth";
-import { getConnectedClients } from "@/lib/api";
-import type { ConnectedClient, ClientsSummary } from "@/lib/api";
+import { getConnectedClients, updateClientMetadata } from "@/lib/api";
+import type { ConnectedClient, ClientsSummary, ClientFacets } from "@/lib/api";
 
 export default function ConnectedClientsPage() {
   const router = useRouter();
   const [clients, setClients] = useState<ConnectedClient[]>([]);
   const [summary, setSummary] = useState<ClientsSummary>({ total: 0, online: 0, offline: 0 });
+  const [facets, setFacets] = useState<ClientFacets>({ tags: [], groups: [] });
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState<"all" | "online" | "offline">("all");
+  const [selectedTag, setSelectedTag] = useState("");
+  const [selectedGroup, setSelectedGroup] = useState("");
 
   useEffect(() => {
     const auth = getAuth();
@@ -33,16 +36,26 @@ export default function ConnectedClientsPage() {
     const auth = getAuth();
     if (!auth) return;
     try {
-      const data = await getConnectedClients(auth.orgId, auth.accessToken);
+      const data = await getConnectedClients(auth.orgId, auth.accessToken, {
+        status: filter === "all" ? undefined : filter,
+        tag: selectedTag || undefined,
+        group: selectedGroup || undefined,
+      });
       setClients(data.clients);
       setSummary(data.summary);
+      setFacets(data.facets);
     } catch {
       // ignore
     }
     setLoading(false);
   }
 
-  const filtered = filter === "all" ? clients : clients.filter((c) => c.status === filter);
+  const groupedClients = clients.reduce<Record<string, ConnectedClient[]>>((acc, client) => {
+    const groupKey = client.groupName?.trim() || "Ungrouped";
+    if (!acc[groupKey]) acc[groupKey] = [];
+    acc[groupKey].push(client);
+    return acc;
+  }, {});
 
   function formatLastSeen(ts: string) {
     const diff = Date.now() - new Date(ts).getTime();
@@ -50,6 +63,27 @@ export default function ConnectedClientsPage() {
     if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`;
     if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`;
     return `${Math.floor(diff / 86400000)}d ago`;
+  }
+
+  async function editClientMetadata(client: ConnectedClient) {
+    const auth = getAuth();
+    if (!auth) return;
+
+    const currentTags = client.tags.join(", ");
+    const nextTags = window.prompt("Set comma-separated tags for this instance.", currentTags);
+    if (nextTags === null) return;
+    const nextGroup = window.prompt("Set group name for this instance (leave empty to clear).", client.groupName ?? "");
+    if (nextGroup === null) return;
+
+    const tags = nextTags
+      .split(",")
+      .map((tag) => tag.trim())
+      .filter((tag) => tag.length > 0);
+    await updateClientMetadata(auth.orgId, client.userId, auth.accessToken, {
+      groupName: nextGroup.trim() ? nextGroup.trim() : null,
+      tags,
+    });
+    await loadClients();
   }
 
   return (
@@ -79,73 +113,141 @@ export default function ConnectedClientsPage() {
               <StatCard label="Offline" value={summary.offline} variant="danger" />
             </div>
 
-            {/* Filter tabs */}
-            <div className="tabs tabs-boxed bg-base-100 p-1 mb-6 w-fit border border-base-300/50">
-              {(["all", "online", "offline"] as const).map((f) => (
-                <button
-                  key={f}
-                  onClick={() => setFilter(f)}
-                  className={`tab tab-sm gap-2 capitalize ${filter === f ? "tab-active" : ""}`}
-                >
-                  {f}
-                  <span className="badge badge-sm badge-ghost">
-                    {f === "all" ? summary.total : f === "online" ? summary.online : summary.offline}
-                  </span>
-                </button>
-              ))}
+            {/* Fleet filters */}
+            <div className="flex flex-wrap items-center gap-3 mb-6">
+              <div className="tabs tabs-boxed bg-base-100 p-1 w-fit border border-base-300/50">
+                {(["all", "online", "offline"] as const).map((f) => (
+                  <button
+                    key={f}
+                    onClick={() => setFilter(f)}
+                    className={`tab tab-sm gap-2 capitalize ${filter === f ? "tab-active" : ""}`}
+                  >
+                    {f}
+                    <span className="badge badge-sm badge-ghost">
+                      {f === "all" ? summary.total : f === "online" ? summary.online : summary.offline}
+                    </span>
+                  </button>
+                ))}
+              </div>
+              <select
+                className="select select-sm select-bordered"
+                value={selectedGroup}
+                onChange={(e) => setSelectedGroup(e.target.value)}
+              >
+                <option value="">All groups</option>
+                {facets.groups.map((group) => (
+                  <option key={group} value={group}>
+                    {group}
+                  </option>
+                ))}
+              </select>
+              <select
+                className="select select-sm select-bordered"
+                value={selectedTag}
+                onChange={(e) => setSelectedTag(e.target.value)}
+              >
+                <option value="">All tags</option>
+                {facets.tags.map((tag) => (
+                  <option key={tag} value={tag}>
+                    {tag}
+                  </option>
+                ))}
+              </select>
+              <button className="btn btn-sm btn-ghost" onClick={() => void loadClients()}>
+                Apply filters
+              </button>
             </div>
 
-            {/* Clients table */}
+            {/* Grouped fleet table */}
             <Card>
-              {filtered.length === 0 ? (
+              {clients.length === 0 ? (
                 <div className="text-center py-10 text-base-content/40">
                   <p className="text-sm">No clients found</p>
                 </div>
               ) : (
-                <div className="overflow-x-auto -mx-5">
-                  <table className="table table-sm">
-                    <thead>
-                      <tr className="text-base-content/40 text-xs uppercase">
-                        <th>Status</th>
-                        <th>User</th>
-                        <th>Email</th>
-                        <th>Role</th>
-                        <th>Client Version</th>
-                        <th>Last Seen</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {filtered.map((client, i) => (
-                        <motion.tr
-                          key={client.userId}
-                          initial={{ opacity: 0 }}
-                          animate={{ opacity: 1 }}
-                          transition={{ delay: i * 0.03 }}
-                          className="table-row-hover"
-                        >
-                          <td>
-                            <div className="flex items-center gap-2">
-                              <div
-                                className={`w-2 h-2 rounded-full ${
-                                  client.status === "online" ? "bg-success animate-pulse" : "bg-base-content/20"
-                                }`}
-                              />
-                              <Badge variant={client.status === "online" ? "success" : "default"}>
-                                {client.status}
-                              </Badge>
-                            </div>
-                          </td>
-                          <td className="font-medium">{client.name ?? "-"}</td>
-                          <td className="text-base-content/50">{client.email}</td>
-                          <td>
-                            <Badge variant={client.role === "admin" ? "info" : "default"}>{client.role}</Badge>
-                          </td>
-                          <td className="font-mono text-xs text-base-content/50">{client.clientVersion ?? "-"}</td>
-                          <td className="text-base-content/50 text-sm">{formatLastSeen(client.lastHeartbeatAt)}</td>
-                        </motion.tr>
-                      ))}
-                    </tbody>
-                  </table>
+                <div className="space-y-5">
+                  {Object.entries(groupedClients)
+                    .sort(([a], [b]) => a.localeCompare(b))
+                    .map(([groupName, groupClients]) => (
+                      <div key={groupName}>
+                        <div className="mb-2 text-sm font-semibold text-base-content/70">
+                          {groupName}{" "}
+                          <span className="text-xs font-normal text-base-content/40">({groupClients.length})</span>
+                        </div>
+                        <div className="overflow-x-auto -mx-5">
+                          <table className="table table-sm">
+                            <thead>
+                              <tr className="text-base-content/40 text-xs uppercase">
+                                <th>Status</th>
+                                <th>User</th>
+                                <th>Email</th>
+                                <th>Role</th>
+                                <th>Tags</th>
+                                <th>Client Version</th>
+                                <th>Last Seen</th>
+                                <th />
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {groupClients.map((client, i) => (
+                                <motion.tr
+                                  key={client.userId}
+                                  initial={{ opacity: 0 }}
+                                  animate={{ opacity: 1 }}
+                                  transition={{ delay: i * 0.03 }}
+                                  className="table-row-hover"
+                                >
+                                  <td>
+                                    <div className="flex items-center gap-2">
+                                      <div
+                                        className={`w-2 h-2 rounded-full ${
+                                          client.status === "online" ? "bg-success animate-pulse" : "bg-base-content/20"
+                                        }`}
+                                      />
+                                      <Badge variant={client.status === "online" ? "success" : "default"}>
+                                        {client.status}
+                                      </Badge>
+                                    </div>
+                                  </td>
+                                  <td className="font-medium">{client.name ?? "-"}</td>
+                                  <td className="text-base-content/50">{client.email}</td>
+                                  <td>
+                                    <Badge variant={client.role === "admin" ? "info" : "default"}>{client.role}</Badge>
+                                  </td>
+                                  <td>
+                                    <div className="flex flex-wrap gap-1">
+                                      {client.tags.length === 0 ? (
+                                        <span className="text-xs text-base-content/40">—</span>
+                                      ) : (
+                                        client.tags.map((tag) => (
+                                          <Badge key={tag} variant="default">
+                                            {tag}
+                                          </Badge>
+                                        ))
+                                      )}
+                                    </div>
+                                  </td>
+                                  <td className="font-mono text-xs text-base-content/50">
+                                    {client.clientVersion ?? "-"}
+                                  </td>
+                                  <td className="text-base-content/50 text-sm">
+                                    {formatLastSeen(client.lastHeartbeatAt)}
+                                  </td>
+                                  <td className="text-right">
+                                    <button
+                                      className="btn btn-xs btn-ghost"
+                                      onClick={() => void editClientMetadata(client)}
+                                    >
+                                      Edit
+                                    </button>
+                                  </td>
+                                </motion.tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        </div>
+                      </div>
+                    ))}
                 </div>
               )}
               <div className="flex items-center gap-2 mt-3 text-xs text-base-content/30">

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -19,6 +19,8 @@ export type AuditQueryFilters = {
   from?: string;
   to?: string;
   limit?: string;
+  tag?: string;
+  group?: string;
 };
 
 async function apiFetch<T>(path: string, opts: FetchOptions = {}): Promise<T> {
@@ -513,6 +515,8 @@ export type ConnectedClient = {
   role: string;
   lastHeartbeatAt: string;
   clientVersion?: string;
+  groupName?: string | null;
+  tags: string[];
   status: "online" | "offline";
 };
 
@@ -522,8 +526,42 @@ export type ClientsSummary = {
   offline: number;
 };
 
-export function getConnectedClients(orgId: string, token: string) {
-  return apiFetch<{ clients: ConnectedClient[]; summary: ClientsSummary }>(`/api/v1/heartbeat/${orgId}`, { token });
+export type ClientFacets = {
+  tags: string[];
+  groups: string[];
+};
+
+export function getConnectedClients(
+  orgId: string,
+  token: string,
+  filters?: { tag?: string; group?: string; status?: "online" | "offline" },
+) {
+  const params = new URLSearchParams();
+  if (filters?.tag) params.set("tag", filters.tag);
+  if (filters?.group) params.set("group", filters.group);
+  if (filters?.status) params.set("status", filters.status);
+  const qs = params.toString();
+
+  return apiFetch<{ clients: ConnectedClient[]; summary: ClientsSummary; facets: ClientFacets }>(
+    `/api/v1/heartbeat/${orgId}${qs ? `?${qs}` : ""}`,
+    { token },
+  );
+}
+
+export function updateClientMetadata(
+  orgId: string,
+  userId: string,
+  token: string,
+  body: { groupName?: string | null; tags?: string[] },
+) {
+  return apiFetch<{ instance: { userId: string; groupName?: string | null; tags: string[] } }>(
+    `/api/v1/heartbeat/${orgId}/${userId}/metadata`,
+    {
+      method: "PUT",
+      token,
+      body,
+    },
+  );
 }
 
 // --- Roles (#61) ---

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -184,6 +184,8 @@ Status values: `approved-org`, `approved-self`, `rejected`
 | `eventType` | Filter by event type                                         |
 | `toolName`  | Filter by tool name                                          |
 | `outcome`   | Filter by outcome (`allowed`, `blocked`, `error`, `success`) |
+| `tag`       | Filter by instance tag (from heartbeat metadata)             |
+| `group`     | Filter by instance group name                                |
 | `from`      | Start time (ISO-8601)                                        |
 | `to`        | End time (ISO-8601)                                          |
 | `limit`     | Max results                                                  |
@@ -227,9 +229,11 @@ offset=0" \
 
 ## Heartbeat
 
-| Method | Path                               | Auth | Description                                                   |
-| ------ | ---------------------------------- | ---- | ------------------------------------------------------------- |
-| `GET`  | `/api/v1/heartbeat/:orgId/:userId` | User | Client heartbeat — returns kill switch state + policy version |
+| Method | Path                                        | Auth         | Description                                                          |
+| ------ | ------------------------------------------- | ------------ | -------------------------------------------------------------------- |
+| `GET`  | `/api/v1/heartbeat/:orgId`                  | Admin/Viewer | List connected instances (supports `status`, `tag`, `group` filters) |
+| `GET`  | `/api/v1/heartbeat/:orgId/:userId`          | User         | Client heartbeat — returns kill switch state + policy version        |
+| `PUT`  | `/api/v1/heartbeat/:orgId/:userId/metadata` | Admin/Viewer | Update instance grouping metadata (`groupName`, `tags`)              |
 
 ### Response
 

--- a/server/src/db/migrations/0007_instance_grouping_tags.sql
+++ b/server/src/db/migrations/0007_instance_grouping_tags.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "client_heartbeats"
+ADD COLUMN "group_name" text;
+
+ALTER TABLE "client_heartbeats"
+ADD COLUMN "tags" jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+CREATE INDEX "client_heartbeats_org_group_idx" ON "client_heartbeats" USING btree ("org_id", "group_name");
+CREATE INDEX "client_heartbeats_tags_gin_idx" ON "client_heartbeats" USING gin ("tags");

--- a/server/src/db/migrations/meta/_journal.json
+++ b/server/src/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1775405450008,
       "tag": "0006_flashy_wendell_rand",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1777060800000,
+      "tag": "0007_instance_grouping_tags",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -231,8 +231,13 @@ export const clientHeartbeats = pgTable(
       .references(() => users.id),
     lastHeartbeatAt: timestamp("last_heartbeat_at", { withTimezone: true }).notNull().defaultNow(),
     clientVersion: text("client_version"),
+    groupName: text("group_name"),
+    tags: jsonb("tags").$type<string[]>().notNull().default([]),
   },
-  (table) => [uniqueIndex("client_heartbeats_org_user_idx").on(table.orgId, table.userId)],
+  (table) => [
+    uniqueIndex("client_heartbeats_org_user_idx").on(table.orgId, table.userId),
+    index("client_heartbeats_org_group_idx").on(table.orgId, table.groupName),
+  ],
 );
 
 // ---------------------------------------------------------------------------

--- a/server/src/routes/audit.ts
+++ b/server/src/routes/audit.ts
@@ -45,6 +45,8 @@ const ExportQuerySchema = z.object({
   from: z.string().optional(),
   to: z.string().optional(),
   limit: z.coerce.number().int().min(1).max(100000).default(10000),
+  tag: z.string().optional(),
+  group: z.string().optional(),
 });
 
 function escapeCsvValue(value: unknown): string {
@@ -75,58 +77,59 @@ export async function auditRoutes(app: FastifyInstance): Promise<void> {
       requireOrg(request, reply, orgId);
       if (reply.sent) return;
 
-    const parseResult = IngestBodySchema.safeParse(request.body);
-    if (!parseResult.success) {
-      return reply.code(400).send({
-        error: "Invalid request body",
-        details: parseResult.error.issues,
-      });
-    }
-
-    const authUser = request.authUser!;
-    const events = parseResult.data.events;
-
-    const invalidOrg = events.find((e) => e.orgId !== orgId);
-    if (invalidOrg) {
-      return reply.code(400).send({
-        error: "Event orgId mismatch: all events must belong to the route orgId",
-      });
-    }
-
-    if (authUser.role !== "admin" && authUser.role !== "super_admin") {
-      const invalidUser = events.find((e) => e.userId !== authUser.userId);
-      if (invalidUser) {
-        return reply.code(403).send({
-          error: "Non-admin users can only submit audit events for their own userId",
+      const parseResult = IngestBodySchema.safeParse(request.body);
+      if (!parseResult.success) {
+        return reply.code(400).send({
+          error: "Invalid request body",
+          details: parseResult.error.issues,
         });
       }
-    }
 
-    await auditService.ingestEvents(events);
+      const authUser = request.authUser!;
+      const events = parseResult.data.events;
 
-    // Track audit ingestion metric (#76)
-    app.metrics.auditEventsCounter.inc(events.length);
-
-    // Deliver webhook events for policy violations and DLP alerts (#43)
-    for (const event of events) {
-      const webhookEvent = AUDIT_TO_WEBHOOK[event.eventType];
-      if (webhookEvent && (event.outcome === "blocked" || event.eventType === "dlp_violation")) {
-        webhookService
-          .deliverEvent(orgId, webhookEvent, {
-            orgId,
-            userId: event.userId,
-            eventType: event.eventType,
-            toolName: event.toolName,
-            outcome: event.outcome,
-            metadata: event.metadata,
-            timestamp: new Date(event.timestamp).toISOString(),
-          })
-          .catch(() => {});
+      const invalidOrg = events.find((e) => e.orgId !== orgId);
+      if (invalidOrg) {
+        return reply.code(400).send({
+          error: "Event orgId mismatch: all events must belong to the route orgId",
+        });
       }
-    }
 
-    return reply.code(201).send({ ingested: events.length });
-  });
+      if (authUser.role !== "admin" && authUser.role !== "super_admin") {
+        const invalidUser = events.find((e) => e.userId !== authUser.userId);
+        if (invalidUser) {
+          return reply.code(403).send({
+            error: "Non-admin users can only submit audit events for their own userId",
+          });
+        }
+      }
+
+      await auditService.ingestEvents(events);
+
+      // Track audit ingestion metric (#76)
+      app.metrics.auditEventsCounter.inc(events.length);
+
+      // Deliver webhook events for policy violations and DLP alerts (#43)
+      for (const event of events) {
+        const webhookEvent = AUDIT_TO_WEBHOOK[event.eventType];
+        if (webhookEvent && (event.outcome === "blocked" || event.eventType === "dlp_violation")) {
+          webhookService
+            .deliverEvent(orgId, webhookEvent, {
+              orgId,
+              userId: event.userId,
+              eventType: event.eventType,
+              toolName: event.toolName,
+              outcome: event.outcome,
+              metadata: event.metadata,
+              timestamp: new Date(event.timestamp).toISOString(),
+            })
+            .catch(() => {});
+        }
+      }
+
+      return reply.code(201).send({ ingested: events.length });
+    },
+  );
 
   // GET /api/v1/audit/:orgId/query - Query with pagination (#38: viewers can query)
   app.get<{
@@ -141,6 +144,8 @@ export async function auditRoutes(app: FastifyInstance): Promise<void> {
       limit?: string;
       offset?: string;
       cursor?: string;
+      tag?: string;
+      group?: string;
     };
   }>("/api/v1/audit/:orgId/query", async (request, reply) => {
     requireAdminOrViewer(request, reply);
@@ -161,6 +166,8 @@ export async function auditRoutes(app: FastifyInstance): Promise<void> {
       limit: query.limit ? parseInt(query.limit, 10) : undefined,
       offset: query.offset ? parseInt(query.offset, 10) : undefined,
       cursor: query.cursor,
+      tag: query.tag,
+      group: query.group,
     };
 
     const [events, total] = await Promise.all([auditService.queryEvents(params), auditService.countEvents(params)]);
@@ -219,6 +226,8 @@ export async function auditRoutes(app: FastifyInstance): Promise<void> {
       from?: string;
       to?: string;
       limit?: string;
+      tag?: string;
+      group?: string;
     };
   }>("/api/v1/audit/:orgId/export", async (request, reply) => {
     requireAdmin(request, reply);
@@ -245,6 +254,8 @@ export async function auditRoutes(app: FastifyInstance): Promise<void> {
       from: query.from ? new Date(query.from) : undefined,
       to: query.to ? new Date(query.to) : undefined,
       limit: query.limit,
+      tag: query.tag,
+      group: query.group,
     };
 
     const dateSuffix = new Date().toISOString().slice(0, 10);

--- a/server/src/routes/heartbeat.test.ts
+++ b/server/src/routes/heartbeat.test.ts
@@ -268,6 +268,8 @@ describe("Heartbeat Routes", () => {
           role: "user",
           lastHeartbeatAt: recentTime,
           clientVersion: "1.0.0",
+          groupName: "Engineering",
+          tags: ["prod", "team-core"],
         },
       ];
 
@@ -283,8 +285,11 @@ describe("Heartbeat Routes", () => {
       const body = res.json();
       expect(body).toHaveProperty("clients");
       expect(body).toHaveProperty("summary");
+      expect(body).toHaveProperty("facets");
       expect(body.summary).toHaveProperty("total", 1);
       expect(body.clients[0]).toHaveProperty("status");
+      expect(body.facets.tags).toContain("prod");
+      expect(body.facets.groups).toContain("Engineering");
     });
 
     it("returns empty client list", async () => {
@@ -306,6 +311,71 @@ describe("Heartbeat Routes", () => {
       const body = res.json();
       expect(body.clients).toEqual([]);
       expect(body.summary).toEqual({ total: 0, online: 0, offline: 0 });
+      expect(body.facets).toEqual({ tags: [], groups: [] });
+    });
+
+    it("updates instance metadata for admin", async () => {
+      const token = generateTestToken(app, {
+        userId: TEST_ADMIN_ID,
+        orgId: TEST_ORG_ID,
+        role: "admin",
+      });
+
+      const updatedRow = { userId: TEST_USER_ID, groupName: "Platform", tags: ["prod", "critical"] };
+      mockDb.update = vi.fn(() => mockDbChain([updatedRow]) as ReturnType<MockDb["update"]>);
+
+      const res = await app.inject({
+        method: "PUT",
+        url: `/api/v1/heartbeat/${TEST_ORG_ID}/${TEST_USER_ID}/metadata`,
+        headers: { authorization: `Bearer ${token}` },
+        payload: { groupName: " Platform ", tags: ["prod", "critical", "prod"] },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ instance: updatedRow });
+    });
+
+    it("filters clients by status using query params", async () => {
+      const token = generateTestToken(app, {
+        userId: TEST_ADMIN_ID,
+        orgId: TEST_ORG_ID,
+        role: "admin",
+      });
+
+      const clients = [
+        {
+          userId: TEST_USER_ID,
+          email: "user@test.com",
+          name: "Test User",
+          role: "user",
+          lastHeartbeatAt: new Date().toISOString(),
+          clientVersion: "1.0.0",
+          groupName: "Ops",
+          tags: ["prod"],
+        },
+        {
+          userId: "00000000-0000-4000-8000-000000000099",
+          email: "offline@test.com",
+          name: "Offline User",
+          role: "user",
+          lastHeartbeatAt: new Date(Date.now() - 20 * 60 * 1000).toISOString(),
+          clientVersion: "1.0.1",
+          groupName: "Ops",
+          tags: ["staging"],
+        },
+      ];
+
+      mockDb.select = vi.fn(() => mockDbChain(clients) as ReturnType<MockDb["select"]>);
+
+      const res = await app.inject({
+        method: "GET",
+        url: `/api/v1/heartbeat/${TEST_ORG_ID}?status=online`,
+        headers: { authorization: `Bearer ${token}` },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().clients).toHaveLength(1);
+      expect(res.json().summary).toEqual({ total: 1, online: 1, offline: 0 });
     });
   });
 });

--- a/server/src/routes/heartbeat.ts
+++ b/server/src/routes/heartbeat.ts
@@ -3,7 +3,7 @@
  */
 
 import type { FastifyInstance } from "fastify";
-import { eq, desc } from "drizzle-orm";
+import { and, eq, desc } from "drizzle-orm";
 import { requireAdminOrViewer, requireOrg } from "../middleware/auth.js";
 import { clientHeartbeats, policies, users } from "../db/schema.js";
 
@@ -12,7 +12,10 @@ export async function heartbeatRoutes(app: FastifyInstance): Promise<void> {
    * GET /api/v1/heartbeat/:orgId
    * List all connected clients for the org (admin or viewer).
    */
-  app.get<{ Params: { orgId: string } }>(
+  app.get<{
+    Params: { orgId: string };
+    Querystring: { tag?: string; group?: string; status?: "online" | "offline" };
+  }>(
     "/api/v1/heartbeat/:orgId",
     { config: { rateLimit: { max: 100, timeWindow: "1 minute" } } },
     async (request, reply) => {
@@ -22,40 +25,109 @@ export async function heartbeatRoutes(app: FastifyInstance): Promise<void> {
       requireOrg(request, reply, orgId);
       if (reply.sent) return;
 
-    const db = app.db;
+      const db = app.db;
+      const tagFilter = request.query.tag?.trim();
+      const groupFilter = request.query.group?.trim();
+      const statusFilter = request.query.status;
 
-    const clients = await db
-      .select({
-        userId: clientHeartbeats.userId,
-        email: users.email,
-        name: users.name,
-        role: users.role,
-        lastHeartbeatAt: clientHeartbeats.lastHeartbeatAt,
-        clientVersion: clientHeartbeats.clientVersion,
-      })
-      .from(clientHeartbeats)
-      .innerJoin(users, eq(clientHeartbeats.userId, users.id))
-      .where(eq(clientHeartbeats.orgId, orgId))
-      .orderBy(desc(clientHeartbeats.lastHeartbeatAt));
+      const clients = await db
+        .select({
+          userId: clientHeartbeats.userId,
+          email: users.email,
+          name: users.name,
+          role: users.role,
+          lastHeartbeatAt: clientHeartbeats.lastHeartbeatAt,
+          clientVersion: clientHeartbeats.clientVersion,
+          groupName: clientHeartbeats.groupName,
+          tags: clientHeartbeats.tags,
+        })
+        .from(clientHeartbeats)
+        .innerJoin(users, eq(clientHeartbeats.userId, users.id))
+        .where(eq(clientHeartbeats.orgId, orgId))
+        .orderBy(desc(clientHeartbeats.lastHeartbeatAt));
 
-    // Determine online/offline status (online = heartbeat within last 5 minutes)
-    const now = Date.now();
-    const ONLINE_THRESHOLD_MS = 5 * 60 * 1000;
+      // Determine online/offline status (online = heartbeat within last 5 minutes)
+      const now = Date.now();
+      const ONLINE_THRESHOLD_MS = 5 * 60 * 1000;
 
-    const enriched = clients.map((c) => ({
-      ...c,
-      status: now - new Date(c.lastHeartbeatAt).getTime() < ONLINE_THRESHOLD_MS ? "online" : "offline",
-    }));
+      const filtered = clients
+        .map((client) => ({
+          ...client,
+          tags: client.tags ?? [],
+          status: now - new Date(client.lastHeartbeatAt).getTime() < ONLINE_THRESHOLD_MS ? "online" : "offline",
+        }))
+        .filter((client) => {
+          if (tagFilter && !client.tags.includes(tagFilter)) return false;
+          if (groupFilter && client.groupName !== groupFilter) return false;
+          if (statusFilter && client.status !== statusFilter) return false;
+          return true;
+        });
 
-    return reply.send({
-      clients: enriched,
-      summary: {
-        total: enriched.length,
-        online: enriched.filter((c) => c.status === "online").length,
-        offline: enriched.filter((c) => c.status === "offline").length,
-      },
-    });
-  });
+      const uniqueTags = Array.from(
+        new Set(
+          clients.flatMap((client) => {
+            const tags = client.tags ?? [];
+            return tags;
+          }),
+        ),
+      ).sort((a, b) => a.localeCompare(b));
+      const uniqueGroups = Array.from(
+        new Set(clients.map((client) => client.groupName).filter((v): v is string => !!v)),
+      ).sort((a, b) => a.localeCompare(b));
+
+      return reply.send({
+        clients: filtered,
+        summary: {
+          total: filtered.length,
+          online: filtered.filter((c) => c.status === "online").length,
+          offline: filtered.filter((c) => c.status === "offline").length,
+        },
+        facets: {
+          tags: uniqueTags,
+          groups: uniqueGroups,
+        },
+      });
+    },
+  );
+
+  app.put<{
+    Params: { orgId: string; userId: string };
+    Body: { groupName?: string | null; tags?: string[] };
+  }>(
+    "/api/v1/heartbeat/:orgId/:userId/metadata",
+    { config: { rateLimit: { max: 60, timeWindow: "1 minute" } } },
+    async (request, reply) => {
+      requireAdminOrViewer(request, reply);
+      if (reply.sent) return;
+      const { orgId, userId } = request.params;
+      requireOrg(request, reply, orgId);
+      if (reply.sent) return;
+
+      const normalizedTags = Array.from(
+        new Set((request.body.tags ?? []).map((tag) => tag.trim()).filter((tag) => tag.length > 0)),
+      );
+      const groupName = request.body.groupName?.trim() || null;
+
+      const [updated] = await app.db
+        .update(clientHeartbeats)
+        .set({
+          groupName,
+          tags: normalizedTags,
+        })
+        .where(and(eq(clientHeartbeats.orgId, orgId), eq(clientHeartbeats.userId, userId)))
+        .returning({
+          userId: clientHeartbeats.userId,
+          groupName: clientHeartbeats.groupName,
+          tags: clientHeartbeats.tags,
+        });
+
+      if (!updated) {
+        return reply.code(404).send({ error: "Instance heartbeat not found" });
+      }
+
+      return reply.send({ instance: updated });
+    },
+  );
 
   /**
    * GET /api/v1/heartbeat/:orgId/:userId
@@ -73,57 +145,59 @@ export async function heartbeatRoutes(app: FastifyInstance): Promise<void> {
       requireOrg(request, reply, orgId);
       if (reply.sent) return;
 
-    const db = app.db;
-    const clientVersionParam = request.query.clientVersion;
+      const db = app.db;
+      const clientVersionParam = request.query.clientVersion;
 
-    // Track heartbeat metric (#76)
-    app.metrics.heartbeatCounter.inc();
+      // Track heartbeat metric (#76)
+      app.metrics.heartbeatCounter.inc();
 
-    // Verify user exists before upserting heartbeat (prevents FK violation).
-    const [user] = await db.select({ id: users.id }).from(users).where(eq(users.id, userId)).limit(1);
-    if (!user) {
-      return reply.code(401).send({ error: "Unknown user; please re-authenticate" });
-    }
+      // Verify user exists before upserting heartbeat (prevents FK violation).
+      const [user] = await db.select({ id: users.id }).from(users).where(eq(users.id, userId)).limit(1);
+      if (!user) {
+        return reply.code(401).send({ error: "Unknown user; please re-authenticate" });
+      }
 
-    // Upsert heartbeat record.
-    await db
-      .insert(clientHeartbeats)
-      .values({
-        orgId,
-        userId,
-        lastHeartbeatAt: new Date(),
-        clientVersion: clientVersionParam ?? null,
-      })
-      .onConflictDoUpdate({
-        target: [clientHeartbeats.orgId, clientHeartbeats.userId],
-        set: {
+      // Upsert heartbeat record.
+      await db
+        .insert(clientHeartbeats)
+        .values({
+          orgId,
+          userId,
           lastHeartbeatAt: new Date(),
           clientVersion: clientVersionParam ?? null,
-        },
+          tags: [],
+        })
+        .onConflictDoUpdate({
+          target: [clientHeartbeats.orgId, clientHeartbeats.userId],
+          set: {
+            lastHeartbeatAt: new Date(),
+            clientVersion: clientVersionParam ?? null,
+          },
+        });
+
+      // Fetch current policy for kill switch status.
+      const [policy] = await db
+        .select({
+          version: policies.version,
+          killSwitch: policies.killSwitch,
+          killSwitchMessage: policies.killSwitchMessage,
+        })
+        .from(policies)
+        .where(eq(policies.orgId, orgId))
+        .limit(1);
+
+      const serverVersion = policy?.version ?? 0;
+      const clientVersion = request.query.policyVersion ? parseInt(request.query.policyVersion, 10) : null;
+
+      // If client sent its version and it differs from server, tell it to refresh.
+      const refreshPolicyNow = clientVersion !== null && !isNaN(clientVersion) && clientVersion !== serverVersion;
+
+      return reply.send({
+        policyVersion: serverVersion,
+        killSwitch: policy?.killSwitch ?? false,
+        killSwitchMessage: policy?.killSwitchMessage ?? undefined,
+        refreshPolicyNow,
       });
-
-    // Fetch current policy for kill switch status.
-    const [policy] = await db
-      .select({
-        version: policies.version,
-        killSwitch: policies.killSwitch,
-        killSwitchMessage: policies.killSwitchMessage,
-      })
-      .from(policies)
-      .where(eq(policies.orgId, orgId))
-      .limit(1);
-
-    const serverVersion = policy?.version ?? 0;
-    const clientVersion = request.query.policyVersion ? parseInt(request.query.policyVersion, 10) : null;
-
-    // If client sent its version and it differs from server, tell it to refresh.
-    const refreshPolicyNow = clientVersion !== null && !isNaN(clientVersion) && clientVersion !== serverVersion;
-
-    return reply.send({
-      policyVersion: serverVersion,
-      killSwitch: policy?.killSwitch ?? false,
-      killSwitchMessage: policy?.killSwitchMessage ?? undefined,
-      refreshPolicyNow,
-    });
-  });
+    },
+  );
 }

--- a/server/src/services/audit-service.ts
+++ b/server/src/services/audit-service.ts
@@ -30,6 +30,8 @@ export type AuditQueryParams = {
   limit?: number;
   offset?: number;
   cursor?: string;
+  tag?: string;
+  group?: string;
 };
 
 export type AuditExportParams = AuditQueryParams & {
@@ -65,6 +67,28 @@ export class AuditService {
     if (params.outcome) conditions.push(eq(auditEvents.outcome, params.outcome));
     if (params.from) conditions.push(gte(auditEvents.timestamp, params.from));
     if (params.to) conditions.push(lte(auditEvents.timestamp, params.to));
+    if (params.tag) {
+      conditions.push(
+        sql`EXISTS (
+          SELECT 1
+          FROM "client_heartbeats" AS ch
+          WHERE ch."org_id" = ${params.orgId}
+            AND ch."user_id" = ${auditEvents.userId}
+            AND ch."tags" ? ${params.tag}
+        )`,
+      );
+    }
+    if (params.group) {
+      conditions.push(
+        sql`EXISTS (
+          SELECT 1
+          FROM "client_heartbeats" AS ch
+          WHERE ch."org_id" = ${params.orgId}
+            AND ch."user_id" = ${auditEvents.userId}
+            AND ch."group_name" = ${params.group}
+        )`,
+      );
+    }
     return conditions;
   }
 


### PR DESCRIPTION
### Motivation
- Provide fleet organization by allowing instances to be grouped and tagged so admins can filter and reason about large fleets (roadmap item for #64).
- Enable filtering of audit queries by instance metadata so investigations and exports can be scoped to groups/tags.

### Description
- Added persistent metadata to heartbeats: `groupName` and `tags` in `server/src/db/schema.ts` with a new migration `server/src/db/migrations/0007_instance_grouping_tags.sql` and indexes for group/tag queries.
- Extended heartbeat APIs: `GET /api/v1/heartbeat/:orgId` supports `status`, `tag`, and `group` filters and returns `facets` for `tags`/`groups`, and `PUT /api/v1/heartbeat/:orgId/:userId/metadata` updates per-instance `groupName`/`tags`.
- Hooked audit query/export into instance metadata by adding `tag`/`group` query params and SQL conditions in `AuditService` to restrict results by matching `client_heartbeats` metadata.
- Updated admin client and UI: `admin/src/lib/api.ts` adds metadata/facet APIs, `Connected Clients` page groups instances, shows tags, adds tag/group filters and an edit action, and `Audit` UI adds tag/group filters; docs updated in `docs/api-reference.md`.

### Testing
- Ran targeted server tests with `pnpm --filter @ClawForgeAI/clawforge-server test -- src/routes/heartbeat.test.ts src/routes/audit.test.ts` and all tests passed (`16` test files, `187` tests passed).
- Built the server with `pnpm --filter @ClawForgeAI/clawforge-server build` and TypeScript build succeeded.
- Built the admin with `pnpm --filter @ClawForgeAI/clawforge-admin build` and the Next.js production build completed successfully (reported unrelated pre-existing ESLint warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec892153348324a8ebfca3d320aecb)