### PR TITLE
chore(workspace): scaffold packages/* + tsconfig.base + dep-cycle guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Prettier
         run: pnpm format:check
 
+      - name: Package dependency guard
+        run: pnpm check:deps
+
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest
@@ -111,10 +114,36 @@ jobs:
       - name: Run plugin tests with coverage
         run: pnpm --filter @clawforgeai/clawforge test -- --coverage
 
+  test-packages:
+    name: Platform Package Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build platform packages
+        run: pnpm -r --filter './packages/*' build
+
+      - name: Test platform packages
+        run: pnpm -r --filter './packages/*' test
+
+      - name: Typecheck platform packages
+        run: pnpm -r --filter './packages/*' typecheck
+
   build-docker:
     name: Docker Build & Healthcheck
     runs-on: ubuntu-latest
-    needs: [lint-and-format, typecheck, test-server, test-plugin]
+    needs: [lint-and-format, typecheck, test-server, test-plugin, test-packages]
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev:server": "pnpm --filter @ClawForgeAI/clawforge-server dev",
     "dev:admin": "pnpm --filter @ClawForgeAI/clawforge-admin dev",
-    "test": "pnpm --filter @ClawForgeAI/clawforge test",
+    "build": "pnpm -r --filter './packages/*' --filter @clawforgeai/clawforge build",
+    "test": "pnpm -r --filter './packages/*' --filter @clawforgeai/clawforge --filter @ClawForgeAI/clawforge-server --filter @ClawForgeAI/clawforge-admin test",
+    "typecheck": "pnpm -r typecheck",
+    "check:deps": "node scripts/check-deps.mjs",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md,yml,yaml}\"",

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@clawforgeai/agent-sdk",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Runtime contract, lifecycle helpers, batching, and policy sync for ClawForge adapters.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@clawforgeai/audit-events": "workspace:*",
+    "@clawforgeai/contracts": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "@vitest/coverage-v8": "^4.1.5",
+    "tsup": "^8.5.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/agent-sdk/src/index.test.ts
+++ b/packages/agent-sdk/src/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { PACKAGE_NAME } from "./index.js";
+
+describe("@clawforgeai/agent-sdk", () => {
+  it("exports PACKAGE_NAME", () => {
+    expect(PACKAGE_NAME).toBe("@clawforgeai/agent-sdk");
+  });
+});

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -1,0 +1,1 @@
+export const PACKAGE_NAME = "@clawforgeai/agent-sdk";

--- a/packages/agent-sdk/tsconfig.json
+++ b/packages/agent-sdk/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/agent-sdk/tsup.config.ts
+++ b/packages/agent-sdk/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  outDir: "dist",
+  clean: true,
+  sourcemap: true,
+  splitting: false,
+  target: "es2023",
+});

--- a/packages/agent-sdk/vitest.config.ts
+++ b/packages/agent-sdk/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts"],
+    },
+  },
+});

--- a/packages/audit-events/package.json
+++ b/packages/audit-events/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@clawforgeai/audit-events",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Audit event writers, retention helpers, and prompt-injection detection for ClawForge.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@clawforgeai/contracts": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "@vitest/coverage-v8": "^4.1.5",
+    "tsup": "^8.5.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/audit-events/src/index.test.ts
+++ b/packages/audit-events/src/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { PACKAGE_NAME } from "./index.js";
+
+describe("@clawforgeai/audit-events", () => {
+  it("exports PACKAGE_NAME", () => {
+    expect(PACKAGE_NAME).toBe("@clawforgeai/audit-events");
+  });
+});

--- a/packages/audit-events/src/index.ts
+++ b/packages/audit-events/src/index.ts
@@ -1,0 +1,1 @@
+export const PACKAGE_NAME = "@clawforgeai/audit-events";

--- a/packages/audit-events/tsconfig.json
+++ b/packages/audit-events/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/audit-events/tsup.config.ts
+++ b/packages/audit-events/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  outDir: "dist",
+  clean: true,
+  sourcemap: true,
+  splitting: false,
+  target: "es2023",
+});

--- a/packages/audit-events/vitest.config.ts
+++ b/packages/audit-events/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts"],
+    },
+  },
+});

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@clawforgeai/auth",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Identity types, session/JWT helpers, and API key parsing for ClawForge.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@clawforgeai/contracts": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "@vitest/coverage-v8": "^4.1.5",
+    "tsup": "^8.5.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/auth/src/index.test.ts
+++ b/packages/auth/src/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { PACKAGE_NAME } from "./index.js";
+
+describe("@clawforgeai/auth", () => {
+  it("exports PACKAGE_NAME", () => {
+    expect(PACKAGE_NAME).toBe("@clawforgeai/auth");
+  });
+});

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,0 +1,1 @@
+export const PACKAGE_NAME = "@clawforgeai/auth";

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/auth/tsup.config.ts
+++ b/packages/auth/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  outDir: "dist",
+  clean: true,
+  sourcemap: true,
+  splitting: false,
+  target: "es2023",
+});

--- a/packages/auth/vitest.config.ts
+++ b/packages/auth/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts"],
+    },
+  },
+});

--- a/packages/claude-code/package.json
+++ b/packages/claude-code/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@clawforgeai/claude-code",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Claude Code runtime adapter for the ClawForge governance platform (skeleton).",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@clawforgeai/agent-sdk": "workspace:*",
+    "@clawforgeai/contracts": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "@vitest/coverage-v8": "^4.1.5",
+    "tsup": "^8.5.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/claude-code/src/index.test.ts
+++ b/packages/claude-code/src/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { PACKAGE_NAME } from "./index.js";
+
+describe("@clawforgeai/claude-code", () => {
+  it("exports PACKAGE_NAME", () => {
+    expect(PACKAGE_NAME).toBe("@clawforgeai/claude-code");
+  });
+});

--- a/packages/claude-code/src/index.ts
+++ b/packages/claude-code/src/index.ts
@@ -1,0 +1,1 @@
+export const PACKAGE_NAME = "@clawforgeai/claude-code";

--- a/packages/claude-code/tsconfig.json
+++ b/packages/claude-code/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/claude-code/tsup.config.ts
+++ b/packages/claude-code/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  outDir: "dist",
+  clean: true,
+  sourcemap: true,
+  splitting: false,
+  target: "es2023",
+});

--- a/packages/claude-code/vitest.config.ts
+++ b/packages/claude-code/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts"],
+    },
+  },
+});

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@clawforgeai/contracts",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Shared Zod schemas and inferred types for the ClawForge platform.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "zod": "^4.4.1"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "@vitest/coverage-v8": "^4.1.5",
+    "tsup": "^8.5.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/contracts/src/index.test.ts
+++ b/packages/contracts/src/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { PACKAGE_NAME } from "./index.js";
+
+describe("@clawforgeai/contracts", () => {
+  it("exports PACKAGE_NAME", () => {
+    expect(PACKAGE_NAME).toBe("@clawforgeai/contracts");
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,0 +1,1 @@
+export const PACKAGE_NAME = "@clawforgeai/contracts";

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/contracts/tsup.config.ts
+++ b/packages/contracts/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  outDir: "dist",
+  clean: true,
+  sourcemap: true,
+  splitting: false,
+  target: "es2023",
+});

--- a/packages/contracts/vitest.config.ts
+++ b/packages/contracts/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts"],
+    },
+  },
+});

--- a/packages/policy-engine/package.json
+++ b/packages/policy-engine/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@clawforgeai/policy-engine",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Pure policy evaluator, kill switch, and scope resolution for ClawForge.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@clawforgeai/contracts": "workspace:*",
+    "@clawforgeai/tool-governance": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "@vitest/coverage-v8": "^4.1.5",
+    "tsup": "^8.5.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/policy-engine/src/index.test.ts
+++ b/packages/policy-engine/src/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { PACKAGE_NAME } from "./index.js";
+
+describe("@clawforgeai/policy-engine", () => {
+  it("exports PACKAGE_NAME", () => {
+    expect(PACKAGE_NAME).toBe("@clawforgeai/policy-engine");
+  });
+});

--- a/packages/policy-engine/src/index.ts
+++ b/packages/policy-engine/src/index.ts
@@ -1,0 +1,1 @@
+export const PACKAGE_NAME = "@clawforgeai/policy-engine";

--- a/packages/policy-engine/tsconfig.json
+++ b/packages/policy-engine/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/policy-engine/tsup.config.ts
+++ b/packages/policy-engine/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  outDir: "dist",
+  clean: true,
+  sourcemap: true,
+  splitting: false,
+  target: "es2023",
+});

--- a/packages/policy-engine/vitest.config.ts
+++ b/packages/policy-engine/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts"],
+    },
+  },
+});

--- a/packages/tool-governance/package.json
+++ b/packages/tool-governance/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@clawforgeai/tool-governance",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Action taxonomy, tool groups, and DLP scanner for ClawForge.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@clawforgeai/contracts": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "@vitest/coverage-v8": "^4.1.5",
+    "tsup": "^8.5.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/tool-governance/src/index.test.ts
+++ b/packages/tool-governance/src/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { PACKAGE_NAME } from "./index.js";
+
+describe("@clawforgeai/tool-governance", () => {
+  it("exports PACKAGE_NAME", () => {
+    expect(PACKAGE_NAME).toBe("@clawforgeai/tool-governance");
+  });
+});

--- a/packages/tool-governance/src/index.ts
+++ b/packages/tool-governance/src/index.ts
@@ -1,0 +1,1 @@
+export const PACKAGE_NAME = "@clawforgeai/tool-governance";

--- a/packages/tool-governance/tsconfig.json
+++ b/packages/tool-governance/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/tool-governance/tsup.config.ts
+++ b/packages/tool-governance/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  outDir: "dist",
+  clean: true,
+  sourcemap: true,
+  splitting: false,
+  target: "es2023",
+});

--- a/packages/tool-governance/vitest.config.ts
+++ b/packages/tool-governance/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts"],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,169 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@7.3.1(@types/node@25.6.0)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))
 
+  packages/agent-sdk:
+    dependencies:
+      '@clawforgeai/audit-events':
+        specifier: workspace:*
+        version: link:../audit-events
+      '@clawforgeai/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.13)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+
+  packages/audit-events:
+    dependencies:
+      '@clawforgeai/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.13)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+
+  packages/auth:
+    dependencies:
+      '@clawforgeai/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.13)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+
+  packages/claude-code:
+    dependencies:
+      '@clawforgeai/agent-sdk':
+        specifier: workspace:*
+        version: link:../agent-sdk
+      '@clawforgeai/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.13)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+
+  packages/contracts:
+    dependencies:
+      zod:
+        specifier: ^4.4.1
+        version: 4.4.2
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.13)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+
+  packages/policy-engine:
+    dependencies:
+      '@clawforgeai/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+      '@clawforgeai/tool-governance':
+        specifier: workspace:*
+        version: link:../tool-governance
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.13)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+
+  packages/tool-governance:
+    dependencies:
+      '@clawforgeai/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.13)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+
   plugin:
     devDependencies:
       '@types/node':
@@ -5857,9 +6020,6 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
-
   zod@4.4.2:
     resolution: {integrity: sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==}
 
@@ -5867,17 +6027,17 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@agentclientprotocol/sdk@0.14.1(zod@4.3.6)':
+  '@agentclientprotocol/sdk@0.14.1(zod@4.4.2)':
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.2
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@anthropic-ai/sdk@0.73.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.73.0(zod@4.4.2)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
-      zod: 4.3.6
+      zod: 4.4.2
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -7467,9 +7627,9 @@ snapshots:
       std-env: 3.10.0
       yoctocolors: 2.1.2
 
-  '@mariozechner/pi-agent-core@0.54.1(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-agent-core@0.54.1(ws@8.19.0)(zod@4.4.2)':
     dependencies:
-      '@mariozechner/pi-ai': 0.54.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.54.1(ws@8.19.0)(zod@4.4.2)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -7479,9 +7639,9 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.54.1(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.54.1(ws@8.19.0)(zod@4.4.2)':
     dependencies:
-      '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.73.0(zod@4.4.2)
       '@aws-sdk/client-bedrock-runtime': 3.995.0
       '@google/genai': 1.42.0
       '@mistralai/mistralai': 1.10.0
@@ -7489,11 +7649,11 @@ snapshots:
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       chalk: 5.6.2
-      openai: 6.10.0(ws@8.19.0)(zod@4.3.6)
+      openai: 6.10.0(ws@8.19.0)(zod@4.4.2)
       partial-json: 0.1.7
       proxy-agent: 6.5.0
       undici: 7.22.0
-      zod-to-json-schema: 3.25.1(zod@4.3.6)
+      zod-to-json-schema: 3.25.1(zod@4.4.2)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -7503,11 +7663,11 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.54.1(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-coding-agent@0.54.1(ws@8.19.0)(zod@4.4.2)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.54.1(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.54.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-agent-core': 0.54.1(ws@8.19.0)(zod@4.4.2)
+      '@mariozechner/pi-ai': 0.54.1(ws@8.19.0)(zod@4.4.2)
       '@mariozechner/pi-tui': 0.54.1
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -10727,14 +10887,14 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  openai@6.10.0(ws@8.19.0)(zod@4.3.6):
+  openai@6.10.0(ws@8.19.0)(zod@4.4.2):
     optionalDependencies:
       ws: 8.19.0
-      zod: 4.3.6
+      zod: 4.4.2
 
   openclaw@2026.2.23(@napi-rs/canvas@0.1.94)(@types/express@5.0.6)(hono@4.12.2)(node-llama-cpp@3.15.1(typescript@6.0.3)):
     dependencies:
-      '@agentclientprotocol/sdk': 0.14.1(zod@4.3.6)
+      '@agentclientprotocol/sdk': 0.14.1(zod@4.4.2)
       '@aws-sdk/client-bedrock': 3.995.0
       '@buape/carbon': 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.12.2)(opusscript@0.0.8)
       '@clack/prompts': 1.0.1
@@ -10745,9 +10905,9 @@ snapshots:
       '@larksuiteoapi/node-sdk': 1.59.0
       '@line/bot-sdk': 10.6.0
       '@lydell/node-pty': 1.2.0-beta.3
-      '@mariozechner/pi-agent-core': 0.54.1(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.54.1(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-coding-agent': 0.54.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-agent-core': 0.54.1(ws@8.19.0)(zod@4.4.2)
+      '@mariozechner/pi-ai': 0.54.1(ws@8.19.0)(zod@4.4.2)
+      '@mariozechner/pi-coding-agent': 0.54.1(ws@8.19.0)(zod@4.4.2)
       '@mariozechner/pi-tui': 0.54.1
       '@mozilla/readability': 0.6.0
       '@napi-rs/canvas': 0.1.94
@@ -10788,7 +10948,7 @@ snapshots:
       undici: 7.22.0
       ws: 8.19.0
       yaml: 2.8.2
-      zod: 4.3.6
+      zod: 4.4.2
     optionalDependencies:
       '@discordjs/opus': 0.10.0
     transitivePeerDependencies:
@@ -12106,12 +12266,10 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  zod-to-json-schema@3.25.1(zod@4.3.6):
+  zod-to-json-schema@3.25.1(zod@4.4.2):
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.2
 
   zod@3.25.76: {}
-
-  zod@4.3.6: {}
 
   zod@4.4.2: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ packages:
   - plugin
   - server
   - admin
+  - packages/*

--- a/scripts/check-deps.mjs
+++ b/scripts/check-deps.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * Dep guard for the ClawForge platform packages.
+ *
+ * Walks every TypeScript file under `packages/<pkg>/src/` and verifies that any
+ * `@clawforgeai/*` import is declared in that package's `dependencies` (or
+ * `peerDependencies`/`devDependencies`). Fails on undeclared imports — this
+ * catches accidental cross-package dependencies that would break the dependency
+ * DAG documented in `docs/technical-strategy.md`.
+ *
+ * Usage:
+ *   node scripts/check-deps.mjs
+ */
+
+import { readFile, readdir } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join, relative, resolve } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+const packagesDir = join(repoRoot, "packages");
+
+const SCOPE = "@clawforgeai/";
+const IMPORT_RE = /(?:^|[^\w])(?:import|export)\s+(?:[\s\S]*?)\s+from\s+["']([^"']+)["']/g;
+const DYNAMIC_IMPORT_RE = /import\s*\(\s*["']([^"']+)["']\s*\)/g;
+
+async function listDirs(dir) {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries.filter((e) => e.isDirectory()).map((e) => e.name);
+}
+
+async function walkTs(dir, files = []) {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return files;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "dist") continue;
+      await walkTs(full, files);
+    } else if (entry.isFile() && /\.(ts|tsx|mts|cts)$/.test(entry.name)) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function extractScopedImports(source) {
+  const found = new Set();
+  for (const re of [IMPORT_RE, DYNAMIC_IMPORT_RE]) {
+    re.lastIndex = 0;
+    let match;
+    while ((match = re.exec(source)) !== null) {
+      const spec = match[1];
+      if (spec.startsWith(SCOPE)) {
+        // Take only the package name (`@scope/name`), drop subpaths.
+        const segments = spec.split("/");
+        if (segments.length >= 2) {
+          found.add(`${segments[0]}/${segments[1]}`);
+        }
+      }
+    }
+  }
+  return found;
+}
+
+async function main() {
+  const pkgDirs = await listDirs(packagesDir);
+  if (pkgDirs.length === 0) {
+    console.log("check-deps: no packages found under packages/ — nothing to check");
+    return;
+  }
+
+  const errors = [];
+
+  for (const name of pkgDirs) {
+    const pkgRoot = join(packagesDir, name);
+    let manifest;
+    try {
+      manifest = JSON.parse(await readFile(join(pkgRoot, "package.json"), "utf8"));
+    } catch (err) {
+      errors.push(`${name}: cannot read package.json (${String(err)})`);
+      continue;
+    }
+    const declared = new Set([
+      ...Object.keys(manifest.dependencies ?? {}),
+      ...Object.keys(manifest.peerDependencies ?? {}),
+      ...Object.keys(manifest.devDependencies ?? {}),
+    ]);
+
+    const tsFiles = await walkTs(join(pkgRoot, "src"));
+    for (const file of tsFiles) {
+      const source = await readFile(file, "utf8");
+      const imports = extractScopedImports(source);
+      for (const dep of imports) {
+        if (dep === manifest.name) continue;
+        if (!declared.has(dep)) {
+          errors.push(
+            `${manifest.name}: undeclared import "${dep}" in ${relative(repoRoot, file)} — add to dependencies in ${relative(repoRoot, join(pkgRoot, "package.json"))}`,
+          );
+        }
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error("check-deps: violations found:");
+    for (const err of errors) console.error("  - " + err);
+    process.exit(1);
+  }
+  console.log(`check-deps: ${pkgDirs.length} package(s) OK`);
+}
+
+main().catch((err) => {
+  console.error("check-deps: unexpected error", err);
+  process.exit(2);
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es2023",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2023"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "noEmit": true,
+    "ignoreDeprecations": "6.0"
+  }
+}


### PR DESCRIPTION
## Summary

PR #1 of the **Phase 1 platform refactor** described in [`docs/technical-strategy.md`](https://github.com/ClawForgeAI/clawforge/blob/main/docs/technical-strategy.md). Lays the workspace shape and tooling so subsequent PRs can extract logic into shared packages without large rebases.

- New private packages under `packages/` (empty placeholders): `contracts`, `auth`, `tool-governance`, `policy-engine`, `audit-events`, `agent-sdk`, `claude-code`. Each builds with tsup, tests with vitest, and typechecks with tsc.
- `pnpm-workspace.yaml` includes `packages/*`. New root `tsconfig.base.json` hoists shared TS flags.
- `scripts/check-deps.mjs` rejects undeclared cross-package `@clawforgeai/*` imports — enforces the dependency DAG documented in the strategy doc.
- Root `package.json` gains `build`, `test`, `typecheck`, `check:deps` scripts that recurse over `packages/*`.
- CI: lint job now runs the dep guard; new `test-packages` job builds + tests + typechecks the platform packages; `build-docker` waits on it.

## Why

Phase 1 of the strategy refactors ClawForge from an OpenClaw-first product into a multi-runtime governance platform. This PR is the workspace foundation — no logic moves yet. Landing the tooling and DAG-enforcement up front means every subsequent extraction PR is just file moves and edits, no scaffolding churn.

## Test plan

- [x] `pnpm install` — succeeds, lock file updates
- [x] `pnpm -r --filter './packages/*' build` — 7 packages build via tsup
- [x] `pnpm -r --filter './packages/*' test` — 7 placeholder tests pass
- [x] `pnpm -r --filter './packages/*' typecheck` — all 7 typecheck clean
- [x] `pnpm check:deps` — `7 package(s) OK`
- [x] `pnpm --filter @clawforgeai/clawforge test` — 163/163 plugin tests still green (no regression)
- [x] `pnpm lint` — 0 errors (92 pre-existing warnings unchanged)
- [x] `pnpm format:check` — only pre-existing formatting issues remain (not introduced here)

## Behavior preservation

No user-visible behavior change:
- Plugin disk paths, defaults, and OpenClaw hook surface untouched.
- Server endpoints and JSON shapes untouched.
- Admin UX untouched.
- Drizzle schema and migrations untouched.

## What's next

PR #2 (`feat(contracts): zod schemas for policy, audit, heartbeat, runtime, approvals`) extracts the contract types from `plugin/src/types.ts` and `server/src/services/policy-service.ts` into `@clawforgeai/contracts` as Zod schemas with `z.infer` types — the source of truth for the rest of the refactor.

Plan file: `/Users/rahular/.claude/plans/mellow-strolling-panda.md` (locally; included sequence is also in the strategy doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)