### PR TITLE
feat(contracts): zod schemas for policy, audit, heartbeat, runtime, approvals

### DIFF
--- a/packages/contracts/src/approvals.test.ts
+++ b/packages/contracts/src/approvals.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { ApprovalDecision, ApprovalRequest } from "./approvals.js";
+
+const ID = "550e8400-e29b-41d4-a716-446655440000";
+
+describe("ApprovalRequest", () => {
+  it("accepts a minimum request without reason or expiry", () => {
+    const result = ApprovalRequest.safeParse({
+      approvalId: ID,
+      runId: ID,
+      actionId: ID,
+      orgId: "o1",
+      requestedBy: "u1",
+      createdAt: "2026-05-10T00:00:00.000Z",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a non-uuid approvalId", () => {
+    const result = ApprovalRequest.safeParse({
+      approvalId: "abc",
+      runId: ID,
+      actionId: ID,
+      orgId: "o1",
+      requestedBy: "u1",
+      createdAt: "2026-05-10T00:00:00.000Z",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("ApprovalDecision", () => {
+  it("accepts approved/denied/expired", () => {
+    for (const d of ["approved", "denied", "expired"] as const) {
+      const result = ApprovalDecision.safeParse({
+        approvalId: ID,
+        decidedBy: "u1",
+        decision: d,
+        decidedAt: "2026-05-10T00:00:00.000Z",
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("rejects an unknown decision", () => {
+    const result = ApprovalDecision.safeParse({
+      approvalId: ID,
+      decidedBy: "u1",
+      decision: "maybe",
+      decidedAt: "2026-05-10T00:00:00.000Z",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/contracts/src/approvals.ts
+++ b/packages/contracts/src/approvals.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+import { Iso, OrgId, UserId, Uuid } from "./common.js";
+
+export const ApprovalRequest = z.object({
+  approvalId: Uuid,
+  runId: Uuid,
+  actionId: Uuid,
+  orgId: OrgId,
+  requestedBy: UserId,
+  reason: z.string().optional(),
+  expiresAt: Iso.optional(),
+  createdAt: Iso,
+});
+export type ApprovalRequest = z.infer<typeof ApprovalRequest>;
+
+export const ApprovalDecisionKind = z.enum(["approved", "denied", "expired"]);
+export type ApprovalDecisionKind = z.infer<typeof ApprovalDecisionKind>;
+
+export const ApprovalDecision = z.object({
+  approvalId: Uuid,
+  decidedBy: UserId,
+  decision: ApprovalDecisionKind,
+  comment: z.string().optional(),
+  decidedAt: Iso,
+});
+export type ApprovalDecision = z.infer<typeof ApprovalDecision>;

--- a/packages/contracts/src/audit.test.ts
+++ b/packages/contracts/src/audit.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { AuditEvent, AuditEventInput, AuditEventType, PromptInjectionAssessment } from "./audit.js";
+
+const FIXTURE_EVENT = {
+  userId: "u1",
+  orgId: "o1",
+  eventType: "tool_call_attempt" as const,
+  toolName: "read",
+  outcome: "allowed" as const,
+  agentId: "agent-1",
+  sessionKey: "sess-1",
+  timestamp: 1700000000000,
+  metadata: { foo: "bar", n: 42 },
+};
+
+describe("AuditEvent (plugin wire shape)", () => {
+  it("accepts the canonical plugin-emitted shape", () => {
+    const result = AuditEvent.safeParse(FIXTURE_EVENT);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts events without optional fields", () => {
+    const result = AuditEvent.safeParse({
+      userId: "u1",
+      orgId: "o1",
+      eventType: "session_end",
+      outcome: "success",
+      timestamp: 1700000000000,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an unknown eventType", () => {
+    const result = AuditEvent.safeParse({ ...FIXTURE_EVENT, eventType: "weird_thing" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an outcome outside the closed set", () => {
+    const result = AuditEvent.safeParse({ ...FIXTURE_EVENT, outcome: "yes" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a string timestamp", () => {
+    const result = AuditEvent.safeParse({ ...FIXTURE_EVENT, timestamp: "now" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("AuditEventInput (server ingestion shape)", () => {
+  it("accepts a string eventType (server is open to new families)", () => {
+    const result = AuditEventInput.safeParse({
+      userId: "u1",
+      orgId: "o1",
+      eventType: "future_event_kind",
+      outcome: "ok",
+      timestamp: 1700000000000,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("AuditEventType", () => {
+  it("includes the agent_enrolled family used by adapter skeletons", () => {
+    expect(AuditEventType.safeParse("agent_enrolled").success).toBe(true);
+  });
+
+  it("includes the gateway crash/restart families", () => {
+    expect(AuditEventType.safeParse("agent_crash").success).toBe(true);
+    expect(AuditEventType.safeParse("agent_restart").success).toBe(true);
+  });
+});
+
+describe("PromptInjectionAssessment", () => {
+  it("accepts confidence between 0 and 100", () => {
+    expect(PromptInjectionAssessment.safeParse({ detected: true, confidence: 0, signals: [] }).success).toBe(true);
+    expect(PromptInjectionAssessment.safeParse({ detected: true, confidence: 100, signals: ["x"] }).success).toBe(true);
+  });
+
+  it("rejects confidence outside 0..100", () => {
+    expect(PromptInjectionAssessment.safeParse({ detected: true, confidence: 101, signals: [] }).success).toBe(false);
+    expect(PromptInjectionAssessment.safeParse({ detected: true, confidence: -1, signals: [] }).success).toBe(false);
+  });
+});

--- a/packages/contracts/src/audit.ts
+++ b/packages/contracts/src/audit.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+import { OrgId, Outcome, UserId } from "./common.js";
+
+export const AuditEventType = z.enum([
+  "tool_call_attempt",
+  "tool_call_result",
+  "session_start",
+  "session_end",
+  "llm_input",
+  "llm_output",
+  "kill_switch_activated",
+  "policy_refresh",
+  "dlp_violation",
+  "agent_enrolled",
+  "agent_crash",
+  "agent_restart",
+]);
+export type AuditEventType = z.infer<typeof AuditEventType>;
+
+/**
+ * Wire shape used by both:
+ *   - the plugin audit logger (uploaded to `POST /api/v1/audit/:orgId/events`)
+ *   - the persisted JSONL buffer at `~/.openclaw/clawforge/audit-buffer.jsonl`
+ *
+ * Server-side ingestion (`AuditEventInput`) accepts the same fields plus
+ * a less constrained `eventType: string` because the server table is open
+ * to future event families. We expose `AuditEventInput` separately to
+ * preserve that latitude.
+ */
+export const AuditEvent = z.object({
+  userId: UserId,
+  orgId: OrgId,
+  agentId: z.string().optional(),
+  sessionKey: z.string().optional(),
+  eventType: AuditEventType,
+  toolName: z.string().optional(),
+  timestamp: z.number().int(),
+  outcome: Outcome,
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+export type AuditEvent = z.infer<typeof AuditEvent>;
+
+/**
+ * Server-side ingestion shape. Looser than `AuditEvent` because the server
+ * accepts new event families without a contracts release.
+ */
+export const AuditEventInput = z.object({
+  userId: UserId,
+  orgId: OrgId,
+  eventType: z.string(),
+  toolName: z.string().optional(),
+  outcome: z.string(),
+  agentId: z.string().optional(),
+  sessionKey: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  timestamp: z.number().int(),
+});
+export type AuditEventInput = z.infer<typeof AuditEventInput>;
+
+export const PromptInjectionAssessment = z.object({
+  detected: z.boolean(),
+  confidence: z.number().int().min(0).max(100),
+  signals: z.array(z.string()),
+});
+export type PromptInjectionAssessment = z.infer<typeof PromptInjectionAssessment>;

--- a/packages/contracts/src/common.test.ts
+++ b/packages/contracts/src/common.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { Iso, OrgId, Outcome, UserId, Uuid } from "./common.js";
+
+describe("Iso", () => {
+  it("accepts ISO datetimes with milliseconds and Z", () => {
+    expect(Iso.safeParse("2026-05-10T00:00:00.000Z").success).toBe(true);
+  });
+
+  it("rejects bare dates", () => {
+    expect(Iso.safeParse("2026-05-10").success).toBe(false);
+  });
+});
+
+describe("Uuid", () => {
+  it("accepts a v4 uuid", () => {
+    expect(Uuid.safeParse("550e8400-e29b-41d4-a716-446655440000").success).toBe(true);
+  });
+
+  it("rejects a non-uuid string", () => {
+    expect(Uuid.safeParse("not-a-uuid").success).toBe(false);
+  });
+});
+
+describe("OrgId / UserId", () => {
+  it("require non-empty strings", () => {
+    expect(OrgId.safeParse("").success).toBe(false);
+    expect(UserId.safeParse("").success).toBe(false);
+    expect(OrgId.safeParse("o1").success).toBe(true);
+    expect(UserId.safeParse("u1").success).toBe(true);
+  });
+});
+
+describe("Outcome", () => {
+  it("accepts the four allowed outcomes", () => {
+    for (const v of ["allowed", "blocked", "error", "success"] as const) {
+      expect(Outcome.safeParse(v).success).toBe(true);
+    }
+  });
+
+  it("rejects unknown outcomes", () => {
+    expect(Outcome.safeParse("maybe").success).toBe(false);
+  });
+});

--- a/packages/contracts/src/common.ts
+++ b/packages/contracts/src/common.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const Iso = z.iso.datetime();
+export const Uuid = z.uuid();
+export const OrgId = z.string().min(1);
+export const UserId = z.string().min(1);
+
+export const Outcome = z.enum(["allowed", "blocked", "error", "success"]);
+export type Outcome = z.infer<typeof Outcome>;

--- a/packages/contracts/src/heartbeat.test.ts
+++ b/packages/contracts/src/heartbeat.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { HeartbeatResponse, OfflineMode } from "./heartbeat.js";
+
+describe("HeartbeatResponse", () => {
+  it("accepts a minimal response", () => {
+    const result = HeartbeatResponse.safeParse({
+      policyVersion: 1,
+      killSwitch: false,
+      refreshPolicyNow: false,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a kill-switch-active response with message", () => {
+    const result = HeartbeatResponse.safeParse({
+      policyVersion: 7,
+      killSwitch: true,
+      killSwitchMessage: "Incident in progress",
+      refreshPolicyNow: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a missing required field", () => {
+    const result = HeartbeatResponse.safeParse({ policyVersion: 1, killSwitch: false });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("OfflineMode", () => {
+  it("accepts the three legal modes", () => {
+    expect(OfflineMode.safeParse("block").success).toBe(true);
+    expect(OfflineMode.safeParse("allow").success).toBe(true);
+    expect(OfflineMode.safeParse("cached").success).toBe(true);
+  });
+
+  it("rejects unknown modes", () => {
+    expect(OfflineMode.safeParse("default").success).toBe(false);
+  });
+});

--- a/packages/contracts/src/heartbeat.ts
+++ b/packages/contracts/src/heartbeat.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+/**
+ * Response body returned by `GET /api/v1/heartbeat/:orgId/:userId`.
+ * Drives the plugin's kill-switch state machine and triggers a policy
+ * refresh when the control plane bumps the policy version.
+ */
+export const HeartbeatResponse = z.object({
+  policyVersion: z.number().int(),
+  killSwitch: z.boolean(),
+  killSwitchMessage: z.string().optional(),
+  refreshPolicyNow: z.boolean(),
+});
+export type HeartbeatResponse = z.infer<typeof HeartbeatResponse>;
+
+export const OfflineMode = z.enum(["block", "allow", "cached"]);
+export type OfflineMode = z.infer<typeof OfflineMode>;

--- a/packages/contracts/src/index.test.ts
+++ b/packages/contracts/src/index.test.ts
@@ -1,8 +1,0 @@
-import { describe, expect, it } from "vitest";
-import { PACKAGE_NAME } from "./index.js";
-
-describe("@clawforgeai/contracts", () => {
-  it("exports PACKAGE_NAME", () => {
-    expect(PACKAGE_NAME).toBe("@clawforgeai/contracts");
-  });
-});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,1 +1,10 @@
 export const PACKAGE_NAME = "@clawforgeai/contracts";
+
+export * from "./common.js";
+export * from "./policy.js";
+export * from "./audit.js";
+export * from "./heartbeat.js";
+export * from "./session.js";
+export * from "./runtime.js";
+export * from "./approvals.js";
+export * from "./plugin-config.js";

--- a/packages/contracts/src/plugin-config.test.ts
+++ b/packages/contracts/src/plugin-config.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { ClawForgePluginConfig } from "./plugin-config.js";
+
+describe("ClawForgePluginConfig", () => {
+  it("accepts an empty config", () => {
+    const result = ClawForgePluginConfig.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts the full plugin manifest shape", () => {
+    const result = ClawForgePluginConfig.safeParse({
+      controlPlaneUrl: "http://localhost:4100",
+      orgId: "o1",
+      sso: { issuerUrl: "https://idp", clientId: "abc" },
+      policyCacheTtlMs: 3_600_000,
+      heartbeatIntervalMs: 30_000,
+      heartbeatFailureThreshold: 10,
+      auditBatchSize: 100,
+      auditFlushIntervalMs: 30_000,
+      offlineMode: "block",
+      maxAuditBufferSize: 10_000,
+      sseEnabled: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("tolerates unknown fields (passthrough)", () => {
+    const result = ClawForgePluginConfig.safeParse({
+      controlPlaneUrl: "http://localhost:4100",
+      futureFlag: { hello: 1 },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data as Record<string, unknown>).futureFlag).toEqual({ hello: 1 });
+    }
+  });
+
+  it("rejects an invalid offlineMode", () => {
+    const result = ClawForgePluginConfig.safeParse({ offlineMode: "default" });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/contracts/src/plugin-config.ts
+++ b/packages/contracts/src/plugin-config.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+import { OfflineMode } from "./heartbeat.js";
+
+/**
+ * Plugin-side runtime configuration. Loaded via OpenClaw's plugin manifest at
+ * `~/.openclaw/openclaw.json`. Unknown fields are tolerated because the
+ * OpenClaw config loader passes the entire record through.
+ */
+export const SsoConfig = z.object({
+  issuerUrl: z.string().optional(),
+  clientId: z.string().optional(),
+});
+export type SsoConfig = z.infer<typeof SsoConfig>;
+
+export const ClawForgePluginConfig = z
+  .object({
+    controlPlaneUrl: z.string().optional(),
+    orgId: z.string().optional(),
+    sso: SsoConfig.optional(),
+    policyCacheTtlMs: z.number().int().optional(),
+    heartbeatIntervalMs: z.number().int().optional(),
+    heartbeatFailureThreshold: z.number().int().optional(),
+    auditBatchSize: z.number().int().optional(),
+    auditFlushIntervalMs: z.number().int().optional(),
+    offlineMode: OfflineMode.optional(),
+    maxAuditBufferSize: z.number().int().optional(),
+    sseEnabled: z.boolean().optional(),
+  })
+  .passthrough();
+export type ClawForgePluginConfig = z.infer<typeof ClawForgePluginConfig>;

--- a/packages/contracts/src/policy.test.ts
+++ b/packages/contracts/src/policy.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { ApprovedSkill, DlpRule, EffectivePolicy, OrgPolicy } from "./policy.js";
+
+const FIXTURE_POLICY = {
+  version: 7,
+  tools: {
+    allow: ["read", "write"],
+    deny: ["exec", "group:web"],
+    profile: "standard",
+  },
+  skills: {
+    approved: [
+      { name: "web-search", key: "web-search@1.2.3", scope: "org" },
+      { name: "scratch", key: "scratch@0.1.0", scope: "self" },
+    ],
+    requireApproval: true,
+  },
+  killSwitch: { active: false },
+  auditLevel: "metadata",
+  dlpRules: [
+    {
+      name: "block-aws-keys",
+      pattern: "AKIA[0-9A-Z]{16}",
+      action: "block",
+      severity: "critical",
+      category: "Secrets",
+      enabled: true,
+      message: "AWS access key detected",
+    },
+  ],
+} as const;
+
+describe("OrgPolicy", () => {
+  it("accepts a fully populated effective policy fixture", () => {
+    const result = OrgPolicy.safeParse(FIXTURE_POLICY);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a policy with active kill switch and message", () => {
+    const result = OrgPolicy.safeParse({
+      ...FIXTURE_POLICY,
+      killSwitch: { active: true, message: "Maintenance window" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a policy with no DLP rules and no tool lists", () => {
+    const result = OrgPolicy.safeParse({
+      version: 1,
+      tools: {},
+      skills: { approved: [], requireApproval: false },
+      killSwitch: { active: false },
+      auditLevel: "off",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an invalid auditLevel", () => {
+    const result = OrgPolicy.safeParse({ ...FIXTURE_POLICY, auditLevel: "verbose" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a missing version", () => {
+    const { version: _v, ...rest } = FIXTURE_POLICY;
+    void _v;
+    const result = OrgPolicy.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  it("EffectivePolicy is a server-side alias for OrgPolicy", () => {
+    expect(EffectivePolicy).toBe(OrgPolicy);
+  });
+});
+
+describe("ApprovedSkill", () => {
+  it("accepts both org and self scopes", () => {
+    expect(ApprovedSkill.safeParse({ name: "a", key: "a@1", scope: "org" }).success).toBe(true);
+    expect(ApprovedSkill.safeParse({ name: "b", key: "b@1", scope: "self" }).success).toBe(true);
+  });
+
+  it("rejects an unknown scope", () => {
+    const result = ApprovedSkill.safeParse({ name: "a", key: "a@1", scope: "fleet" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("DlpRule", () => {
+  it("accepts a minimal rule (no optional fields)", () => {
+    const result = DlpRule.safeParse({
+      name: "min",
+      pattern: "secret",
+      action: "warn",
+      severity: "info",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an invalid action", () => {
+    const result = DlpRule.safeParse({
+      name: "x",
+      pattern: ".",
+      action: "kill",
+      severity: "critical",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/contracts/src/policy.ts
+++ b/packages/contracts/src/policy.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+
+export const DlpAction = z.enum(["block", "warn", "log"]);
+export type DlpAction = z.infer<typeof DlpAction>;
+
+export const DlpSeverity = z.enum(["critical", "high", "medium", "info"]);
+export type DlpSeverity = z.infer<typeof DlpSeverity>;
+
+export const DlpRule = z.object({
+  name: z.string(),
+  pattern: z.string(),
+  action: DlpAction,
+  severity: DlpSeverity,
+  category: z.string().optional(),
+  enabled: z.boolean().optional(),
+  message: z.string().optional(),
+});
+export type DlpRule = z.infer<typeof DlpRule>;
+
+export const DlpViolation = z.object({
+  ruleName: z.string(),
+  action: DlpAction,
+  severity: DlpSeverity,
+  redactedContext: z.string(),
+  category: z.string().optional(),
+});
+export type DlpViolation = z.infer<typeof DlpViolation>;
+
+export const DlpScanResult = z.object({
+  violations: z.array(DlpViolation),
+  effectiveAction: DlpAction.nullable(),
+  scannedFields: z.number().int().nonnegative(),
+});
+export type DlpScanResult = z.infer<typeof DlpScanResult>;
+
+export const ApprovedSkill = z.object({
+  name: z.string(),
+  key: z.string(),
+  scope: z.enum(["org", "self"]),
+});
+export type ApprovedSkill = z.infer<typeof ApprovedSkill>;
+
+export const AuditLevel = z.enum(["full", "metadata", "off"]);
+export type AuditLevel = z.infer<typeof AuditLevel>;
+
+export const KillSwitchState = z.object({
+  active: z.boolean(),
+  message: z.string().optional(),
+});
+export type KillSwitchState = z.infer<typeof KillSwitchState>;
+
+/**
+ * The effective policy projected for a single user. This is the wire shape
+ * returned by `GET /api/v1/policies/:orgId/effective` and the shape persisted
+ * by the plugin at `~/.openclaw/clawforge/org-policy.json`.
+ */
+export const OrgPolicy = z.object({
+  version: z.number().int(),
+  tools: z.object({
+    allow: z.array(z.string()).optional(),
+    deny: z.array(z.string()).optional(),
+    profile: z.string().optional(),
+  }),
+  skills: z.object({
+    approved: z.array(ApprovedSkill),
+    requireApproval: z.boolean(),
+  }),
+  killSwitch: KillSwitchState,
+  auditLevel: AuditLevel,
+  dlpRules: z.array(DlpRule).optional(),
+});
+export type OrgPolicy = z.infer<typeof OrgPolicy>;
+
+/** Server-side alias for OrgPolicy used by `policy-service.ts`. Same shape. */
+export const EffectivePolicy = OrgPolicy;
+export type EffectivePolicy = OrgPolicy;

--- a/packages/contracts/src/runtime.test.ts
+++ b/packages/contracts/src/runtime.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { Action, ActionKind, AgentInstance, Run, RuntimeKind, RuntimeRegistration } from "./runtime.js";
+
+const SAMPLE_REGISTRATION = {
+  runtimeKind: "openclaw" as const,
+  runtimeVersion: "1.2.3",
+  adapterVersion: "0.1.6",
+  capabilities: { preToolHooks: true, sse: true, artifacts: false, approvals: true },
+  registeredAt: "2026-05-10T00:00:00.000Z",
+};
+
+describe("RuntimeKind", () => {
+  it("includes openclaw, claude-code, codex, custom", () => {
+    expect(RuntimeKind.safeParse("openclaw").success).toBe(true);
+    expect(RuntimeKind.safeParse("claude-code").success).toBe(true);
+    expect(RuntimeKind.safeParse("codex").success).toBe(true);
+    expect(RuntimeKind.safeParse("custom").success).toBe(true);
+    expect(RuntimeKind.safeParse("openai").success).toBe(false);
+  });
+});
+
+describe("RuntimeRegistration", () => {
+  it("accepts the canonical shape", () => {
+    expect(RuntimeRegistration.safeParse(SAMPLE_REGISTRATION).success).toBe(true);
+  });
+
+  it("rejects a missing capability", () => {
+    const broken = { ...SAMPLE_REGISTRATION, capabilities: { preToolHooks: true } };
+    expect(RuntimeRegistration.safeParse(broken).success).toBe(false);
+  });
+});
+
+describe("AgentInstance", () => {
+  it("accepts an instance with a deviceId only", () => {
+    const result = AgentInstance.safeParse({
+      agentInstanceId: "550e8400-e29b-41d4-a716-446655440000",
+      orgId: "o1",
+      runtimeKind: "openclaw",
+      deviceId: "laptop-42",
+      userId: "u1",
+      registration: SAMPLE_REGISTRATION,
+      enrolledAt: "2026-05-10T00:00:00.000Z",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an invalid agentInstanceId", () => {
+    const result = AgentInstance.safeParse({
+      agentInstanceId: "not-a-uuid",
+      orgId: "o1",
+      runtimeKind: "openclaw",
+      userId: "u1",
+      registration: SAMPLE_REGISTRATION,
+      enrolledAt: "2026-05-10T00:00:00.000Z",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("Run", () => {
+  it("accepts a minimum running run", () => {
+    const result = Run.safeParse({
+      runId: "550e8400-e29b-41d4-a716-446655440000",
+      agentInstanceId: "550e8400-e29b-41d4-a716-446655440001",
+      orgId: "o1",
+      userId: "u1",
+      status: "running",
+      startedAt: "2026-05-10T00:00:00.000Z",
+      policyVersionAtStart: 7,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("Action", () => {
+  it("accepts a tool_call action without args", () => {
+    const result = Action.safeParse({
+      actionId: "550e8400-e29b-41d4-a716-446655440000",
+      runId: "550e8400-e29b-41d4-a716-446655440001",
+      kind: "tool_call",
+      toolName: "read",
+      requestedAt: "2026-05-10T00:00:00.000Z",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("ActionKind covers shell_exec, file_*, network_request, mcp_call", () => {
+    for (const k of ["shell_exec", "file_read", "file_write", "network_request", "mcp_call"]) {
+      expect(ActionKind.safeParse(k).success).toBe(true);
+    }
+  });
+});

--- a/packages/contracts/src/runtime.ts
+++ b/packages/contracts/src/runtime.ts
@@ -1,0 +1,93 @@
+import { z } from "zod";
+import { OrgId, UserId, Uuid, Iso } from "./common.js";
+
+/** Identifies which runtime the adapter governs. */
+export const RuntimeKind = z.enum(["openclaw", "claude-code", "codex", "custom"]);
+export type RuntimeKind = z.infer<typeof RuntimeKind>;
+
+/**
+ * Static metadata an adapter declares when it joins the control plane.
+ * `capabilities` are the ones the runtime supports today — they let the
+ * server short-circuit features the runtime can't honor (e.g. pre-tool
+ * hooks for SDK-only runtimes).
+ */
+export const RuntimeRegistration = z.object({
+  runtimeKind: RuntimeKind,
+  runtimeVersion: z.string(),
+  adapterVersion: z.string(),
+  capabilities: z.object({
+    preToolHooks: z.boolean(),
+    sse: z.boolean(),
+    artifacts: z.boolean(),
+    approvals: z.boolean(),
+  }),
+  registeredAt: Iso,
+});
+export type RuntimeRegistration = z.infer<typeof RuntimeRegistration>;
+
+/**
+ * One running adapter instance — typically one per (user, device, runtime).
+ * `deviceId` and `runnerId` are mutually optional: laptop-installed agents
+ * report a `deviceId`, hosted runners report a `runnerId`, custom service
+ * agents may report neither.
+ */
+export const AgentInstance = z.object({
+  agentInstanceId: Uuid,
+  orgId: OrgId,
+  runtimeKind: RuntimeKind,
+  deviceId: z.string().optional(),
+  runnerId: z.string().optional(),
+  userId: UserId,
+  registration: RuntimeRegistration,
+  enrolledAt: Iso,
+});
+export type AgentInstance = z.infer<typeof AgentInstance>;
+
+export const RunStatus = z.enum(["starting", "running", "paused", "completed", "failed", "cancelled"]);
+export type RunStatus = z.infer<typeof RunStatus>;
+
+export const Run = z.object({
+  runId: Uuid,
+  agentInstanceId: Uuid,
+  orgId: OrgId,
+  userId: UserId,
+  status: RunStatus,
+  startedAt: Iso,
+  endedAt: Iso.optional(),
+  parentRunId: Uuid.optional(),
+  policyVersionAtStart: z.number().int(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+export type Run = z.infer<typeof Run>;
+
+/**
+ * Action taxonomy normalized across runtimes. `tool_call` is the legacy entry
+ * for compatibility with the OpenClaw plugin's existing `tool_call_attempt`
+ * audit events; the more specific kinds (shell_exec, file_*, network_request)
+ * are used by the platform when adapters can supply that detail.
+ */
+export const ActionKind = z.enum([
+  "tool_call",
+  "shell_exec",
+  "file_read",
+  "file_write",
+  "network_request",
+  "mcp_call",
+  "repo_push",
+  "secret_access",
+]);
+export type ActionKind = z.infer<typeof ActionKind>;
+
+export const RiskTier = z.enum(["low", "medium", "high", "critical"]);
+export type RiskTier = z.infer<typeof RiskTier>;
+
+export const Action = z.object({
+  actionId: Uuid,
+  runId: Uuid,
+  kind: ActionKind,
+  toolName: z.string().optional(),
+  args: z.record(z.string(), z.unknown()).optional(),
+  requestedAt: Iso,
+  riskTier: RiskTier.optional(),
+});
+export type Action = z.infer<typeof Action>;

--- a/packages/contracts/src/session.test.ts
+++ b/packages/contracts/src/session.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { CachedPolicy, SessionTokens } from "./session.js";
+
+describe("SessionTokens", () => {
+  it("accepts a plugin on-disk session", () => {
+    const result = SessionTokens.safeParse({
+      accessToken: "jwt.access",
+      refreshToken: "jwt.refresh",
+      expiresAt: 1700000000000,
+      userId: "u1",
+      orgId: "o1",
+      email: "user@example.com",
+      roles: ["user"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a session without a refresh token (enrollment flow)", () => {
+    const result = SessionTokens.safeParse({
+      accessToken: "jwt.access",
+      userId: "u1",
+      orgId: "o1",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty userId", () => {
+    const result = SessionTokens.safeParse({ accessToken: "j", userId: "", orgId: "o" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("CachedPolicy", () => {
+  it("accepts a wrapped policy with TTL metadata", () => {
+    const result = CachedPolicy.safeParse({
+      policy: {
+        version: 1,
+        tools: {},
+        skills: { approved: [], requireApproval: false },
+        killSwitch: { active: false },
+        auditLevel: "metadata",
+      },
+      fetchedAt: 1700000000000,
+      ttlMs: 3_600_000,
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/contracts/src/session.ts
+++ b/packages/contracts/src/session.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+import { OrgId, UserId } from "./common.js";
+import { OrgPolicy } from "./policy.js";
+
+/**
+ * On-disk session shape persisted by the plugin at
+ * `~/.openclaw/clawforge/session.json` (mode 0o600). Returned by
+ * `POST /api/v1/auth/exchange|login|enroll`.
+ */
+export const SessionTokens = z.object({
+  accessToken: z.string(),
+  refreshToken: z.string().optional(),
+  expiresAt: z.number().int().optional(),
+  userId: UserId,
+  orgId: OrgId,
+  email: z.string().optional(),
+  roles: z.array(z.string()).optional(),
+});
+export type SessionTokens = z.infer<typeof SessionTokens>;
+
+/**
+ * Plugin-side wrapper used by the on-disk policy cache at
+ * `~/.openclaw/clawforge/org-policy.json`.
+ */
+export const CachedPolicy = z.object({
+  policy: OrgPolicy,
+  fetchedAt: z.number().int(),
+  ttlMs: z.number().int(),
+});
+export type CachedPolicy = z.infer<typeof CachedPolicy>;


### PR DESCRIPTION
## Summary

PR #2 of the **Phase 1 platform refactor** (`docs/technical-strategy.md`). Lands `@clawforgeai/contracts` — the Zod-first source of truth that plugin/server/admin will all import.

> **Stacked on [#204](https://github.com/ClawForgeAI/clawforge/pull/204).** Base branch is `feat/phase1-pr1-scaffolding`. Once #204 merges to main, this auto-retargets to main.

## What

| Module | Exports |
|---|---|
| `common.ts` | `Iso`, `Uuid`, `OrgId`, `UserId`, `Outcome` |
| `policy.ts` | `OrgPolicy` + `EffectivePolicy` alias, `ApprovedSkill`, `DlpRule`, `DlpViolation`, `DlpScanResult`, `AuditLevel`, `KillSwitchState` |
| `audit.ts` | `AuditEvent` (plugin wire), `AuditEventInput` (server ingestion), `AuditEventType`, `PromptInjectionAssessment` |
| `heartbeat.ts` | `HeartbeatResponse`, `OfflineMode` |
| `session.ts` | `SessionTokens`, `CachedPolicy` |
| `runtime.ts` | `RuntimeKind`, `RuntimeRegistration`, `AgentInstance`, `Run`, `RunStatus`, `Action`, `ActionKind`, `RiskTier` |
| `approvals.ts` | `ApprovalRequest`, `ApprovalDecision`, `ApprovalDecisionKind` |
| `plugin-config.ts` | `ClawForgePluginConfig` (passthrough), `SsoConfig` |

Every schema exposes both the Zod runtime value (`OrgPolicy`) and an inferred TS type alias of the same name (`type OrgPolicy = z.infer<typeof OrgPolicy>`).

## Why

- Locked decision: **Zod is the source of truth**. `z.infer` makes the TS types fall out for free, so contract drift between plugin/server/admin becomes impossible by construction.
- Field shapes mirror `plugin/src/types.ts` and server's `EffectivePolicy` **byte-for-byte** — when PR #8/#9 swap their local types for these, no wire payload or on-disk JSON shape changes.
- New strategy-doc entities (`Run`, `Action`, `AgentInstance`, `RuntimeRegistration`, `ApprovalRequest`/`ApprovalDecision`) land here so the agent-sdk and Claude Code skeleton in later PRs can compile.
- `AuditEventInput` is intentionally looser than `AuditEvent` — server ingestion stays open to future event families without forcing a contracts release.

## Test plan

- [x] `pnpm --filter @clawforgeai/contracts test` — **52/52 pass** across 8 modules
- [x] `pnpm --filter @clawforgeai/contracts build` — `dist/index.js` 7 KB, `dist/index.d.ts` 19 KB
- [x] `pnpm -r --filter './packages/*' typecheck` — clean
- [x] `pnpm check:deps` — `7 package(s) OK` (DAG enforced)
- [x] `pnpm --filter @clawforgeai/clawforge test` — **163/163 still green** (no regression)
- [x] `pnpm lint` — 0 errors (92 pre-existing warnings unchanged)
- [x] `pnpm format:check` — only pre-existing files flagged

Tests cover happy-path `safeParse` fixtures and rejection paths for every closed enum (`auditLevel`, `scope`, DLP `action`, `ApprovalDecisionKind`, `RuntimeKind`, `OfflineMode`, etc.) and required-field omissions.

## Behavior preservation

This PR adds a new package only. Plugin, server, and admin don't import from contracts yet — that happens in PRs #8/#9/#10. No wire shapes, no on-disk paths, no UX changes here.

## What's next

PR #3: `feat(auth): identity types + JWT helpers + api-key parsing` (`@clawforgeai/auth`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)