### PR TITLE
feat(auth): identity types + JWT helpers + api-key parsing

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -23,7 +23,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@clawforgeai/contracts": "workspace:*"
+    "@clawforgeai/contracts": "workspace:*",
+    "jose": "^6.2.3"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/packages/auth/src/api-key.test.ts
+++ b/packages/auth/src/api-key.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  API_KEY_LIVE_PREFIX,
+  API_KEY_LOOKUP_PREFIX_LENGTH,
+  API_KEY_TEST_PREFIX,
+  isApiKey,
+  parseApiKey,
+} from "./api-key.js";
+
+const LIVE_KEY = `${API_KEY_LIVE_PREFIX}AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`;
+const TEST_KEY = `${API_KEY_TEST_PREFIX}BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB`;
+const SAMPLE_JWT = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiJ1MSJ9.signaturepart";
+
+describe("isApiKey", () => {
+  it("recognises cf_live_ tokens", () => {
+    expect(isApiKey(LIVE_KEY)).toBe(true);
+  });
+
+  it("recognises cf_test_ tokens", () => {
+    expect(isApiKey(TEST_KEY)).toBe(true);
+  });
+
+  it("rejects JWT-shaped tokens", () => {
+    expect(isApiKey(SAMPLE_JWT)).toBe(false);
+  });
+
+  it("rejects an empty string", () => {
+    expect(isApiKey("")).toBe(false);
+  });
+});
+
+describe("parseApiKey", () => {
+  it("returns null for non-API-key tokens", () => {
+    expect(parseApiKey(SAMPLE_JWT)).toBeNull();
+  });
+
+  it("classifies a cf_live_ token as live", () => {
+    const parsed = parseApiKey(LIVE_KEY);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.environment).toBe("live");
+  });
+
+  it("classifies a cf_test_ token as test", () => {
+    const parsed = parseApiKey(TEST_KEY);
+    expect(parsed!.environment).toBe("test");
+  });
+
+  it("computes lookupPrefix as the first 16 chars (matches server keyPrefix)", () => {
+    const parsed = parseApiKey(LIVE_KEY)!;
+    expect(parsed.lookupPrefix).toBe(LIVE_KEY.slice(0, API_KEY_LOOKUP_PREFIX_LENGTH));
+    expect(parsed.lookupPrefix.length).toBe(16);
+    expect(parsed.lookupPrefix.startsWith("cf_live_")).toBe(true);
+  });
+
+  it("preserves the original token for downstream bcrypt verification", () => {
+    const parsed = parseApiKey(LIVE_KEY)!;
+    expect(parsed.token).toBe(LIVE_KEY);
+  });
+});

--- a/packages/auth/src/api-key.ts
+++ b/packages/auth/src/api-key.ts
@@ -1,0 +1,52 @@
+/**
+ * API key parsing for ClawForge service accounts (#44).
+ *
+ * Format (unchanged from `server/src/routes/api-keys.ts`):
+ *
+ *   cf_live_<base64url(32 bytes)>   # production keys
+ *   cf_test_<base64url(32 bytes)>   # non-production / staging keys
+ *
+ * Lookup in the DB is by the first 16 characters (the `keyPrefix` column).
+ * Verification uses bcrypt against `keyHash`.
+ *
+ * These helpers are pure: they let server middleware (and any future
+ * worker/CLI) classify and parse the token without pulling in Fastify.
+ */
+
+export const API_KEY_LIVE_PREFIX = "cf_live_";
+export const API_KEY_TEST_PREFIX = "cf_test_";
+export const API_KEY_LOOKUP_PREFIX_LENGTH = 16;
+
+export type ApiKeyEnvironment = "live" | "test";
+
+export type ParsedApiKey = {
+  /** Original token, unchanged. Never log this. */
+  token: string;
+  /** "live" for cf_live_*, "test" for cf_test_*. */
+  environment: ApiKeyEnvironment;
+  /** First 16 chars — used as a DB lookup index. */
+  lookupPrefix: string;
+};
+
+/**
+ * Detect whether a bearer token is an API key. Cheap string check; safe to
+ * run on every request.
+ */
+export function isApiKey(token: string): boolean {
+  return token.startsWith(API_KEY_LIVE_PREFIX) || token.startsWith(API_KEY_TEST_PREFIX);
+}
+
+/**
+ * Parse a bearer token as an API key. Returns `null` if the token is not an
+ * API key (caller should fall through to JWT verification).
+ *
+ * Does not contact a DB and does not verify the bcrypt hash — verification
+ * is the caller's responsibility (the existing server middleware uses
+ * `bcrypt.compare(token, key.keyHash)`).
+ */
+export function parseApiKey(token: string): ParsedApiKey | null {
+  if (!isApiKey(token)) return null;
+  const environment: ApiKeyEnvironment = token.startsWith(API_KEY_LIVE_PREFIX) ? "live" : "test";
+  const lookupPrefix = token.slice(0, API_KEY_LOOKUP_PREFIX_LENGTH);
+  return { token, environment, lookupPrefix };
+}

--- a/packages/auth/src/identities.test.ts
+++ b/packages/auth/src/identities.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  HUMAN_ROLES,
+  isAgentInstance,
+  isHuman,
+  isServiceAccount,
+  type AgentInstanceIdentity,
+  type ClawForgeIdentity,
+  type HumanIdentity,
+  type ServiceAccountIdentity,
+} from "./identities.js";
+
+const HUMAN: HumanIdentity = {
+  kind: "human",
+  userId: "u1",
+  orgId: "o1",
+  email: "u1@example.com",
+  role: "admin",
+};
+
+const SERVICE: ServiceAccountIdentity = {
+  kind: "service_account",
+  apiKeyId: "key1",
+  orgId: "o1",
+  createdByUserId: "u1",
+  email: "api-key:ci-runner",
+  role: "viewer",
+};
+
+const AGENT: AgentInstanceIdentity = {
+  kind: "agent_instance",
+  agentInstanceId: "agent-1",
+  orgId: "o1",
+  userId: "u1",
+};
+
+describe("identity guards", () => {
+  it("isHuman narrows correctly", () => {
+    const ids: ClawForgeIdentity[] = [HUMAN, SERVICE, AGENT];
+    expect(ids.filter(isHuman)).toEqual([HUMAN]);
+  });
+
+  it("isServiceAccount narrows correctly", () => {
+    const ids: ClawForgeIdentity[] = [HUMAN, SERVICE, AGENT];
+    expect(ids.filter(isServiceAccount)).toEqual([SERVICE]);
+  });
+
+  it("isAgentInstance narrows correctly", () => {
+    const ids: ClawForgeIdentity[] = [HUMAN, SERVICE, AGENT];
+    expect(ids.filter(isAgentInstance)).toEqual([AGENT]);
+  });
+});
+
+describe("HUMAN_ROLES", () => {
+  it("matches the server's role enum exactly", () => {
+    expect(HUMAN_ROLES).toEqual(["super_admin", "admin", "policy_admin", "security_admin", "viewer", "user"]);
+  });
+});

--- a/packages/auth/src/identities.ts
+++ b/packages/auth/src/identities.ts
@@ -1,0 +1,99 @@
+/**
+ * Identity separation per the strategy doc: humans, devices, hosted runners,
+ * service accounts (API keys), and agent instances are different trust models.
+ *
+ * Today's server collapses everything into `AuthUser`. These types let
+ * subsequent refactors split that out without touching the wire shape.
+ *
+ * Plain string aliases are used here intentionally — runtime ID validation
+ * (non-empty etc.) lives in `@clawforgeai/contracts`; this package exposes
+ * the corresponding TypeScript types for typed callers.
+ */
+
+export type HumanRole = "super_admin" | "admin" | "policy_admin" | "security_admin" | "viewer" | "user";
+
+export const HUMAN_ROLES: readonly HumanRole[] = [
+  "super_admin",
+  "admin",
+  "policy_admin",
+  "security_admin",
+  "viewer",
+  "user",
+];
+
+export type HumanIdentity = {
+  kind: "human";
+  userId: string;
+  orgId: string;
+  email: string;
+  role: HumanRole;
+};
+
+/**
+ * A laptop or workstation an agent is installed on. `deviceId` is stable
+ * across enrollments for the same machine; the plugin stores it in the
+ * session file.
+ */
+export type DeviceIdentity = {
+  kind: "device";
+  deviceId: string;
+  orgId: string;
+  /** The human user who enrolled this device. */
+  enrolledByUserId: string;
+};
+
+/**
+ * A hosted runner (CI box, cloud sandbox, managed worker). Distinct from
+ * `DeviceIdentity` because runners are typically multi-tenant and should
+ * carry their own scoped credentials.
+ */
+export type RunnerIdentity = {
+  kind: "runner";
+  runnerId: string;
+  orgId: string;
+};
+
+/**
+ * Service-account / API-key identity. Maps to the existing `apiKeys` table.
+ * `email` is a synthetic label of the form `api-key:<name>` — keep this
+ * shape unchanged so the server's existing audit log stays consistent.
+ */
+export type ServiceAccountIdentity = {
+  kind: "service_account";
+  apiKeyId: string;
+  orgId: string;
+  /** The user who owns/created this key. */
+  createdByUserId: string;
+  email: string;
+  role: HumanRole;
+};
+
+/**
+ * The agent instance itself. Not yet emitted by any current code path —
+ * this is what an adapter's `registerAgent()` returns in PRs #7/#11.
+ */
+export type AgentInstanceIdentity = {
+  kind: "agent_instance";
+  agentInstanceId: string;
+  orgId: string;
+  userId: string;
+};
+
+export type ClawForgeIdentity =
+  | HumanIdentity
+  | DeviceIdentity
+  | RunnerIdentity
+  | ServiceAccountIdentity
+  | AgentInstanceIdentity;
+
+export function isHuman(identity: ClawForgeIdentity): identity is HumanIdentity {
+  return identity.kind === "human";
+}
+
+export function isServiceAccount(identity: ClawForgeIdentity): identity is ServiceAccountIdentity {
+  return identity.kind === "service_account";
+}
+
+export function isAgentInstance(identity: ClawForgeIdentity): identity is AgentInstanceIdentity {
+  return identity.kind === "agent_instance";
+}

--- a/packages/auth/src/index.test.ts
+++ b/packages/auth/src/index.test.ts
@@ -1,8 +1,0 @@
-import { describe, expect, it } from "vitest";
-import { PACKAGE_NAME } from "./index.js";
-
-describe("@clawforgeai/auth", () => {
-  it("exports PACKAGE_NAME", () => {
-    expect(PACKAGE_NAME).toBe("@clawforgeai/auth");
-  });
-});

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,1 +1,9 @@
 export const PACKAGE_NAME = "@clawforgeai/auth";
+
+export * from "./identities.js";
+export * from "./jwt.js";
+export * from "./api-key.js";
+
+// Re-export the session shape from contracts so adapters can grab it from one
+// place when they handle auth flows.
+export type { SessionTokens } from "@clawforgeai/contracts";

--- a/packages/auth/src/jwt.test.ts
+++ b/packages/auth/src/jwt.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { jwtClaimsToHumanIdentity, signClawForgeJwt, verifyClawForgeJwt } from "./jwt.js";
+
+const SECRET = "test-secret-key-not-for-prod-do-not-use-anywhere-real";
+const CLAIMS = {
+  userId: "u1",
+  orgId: "o1",
+  email: "u1@example.com",
+  role: "admin" as const,
+};
+
+describe("signClawForgeJwt / verifyClawForgeJwt", () => {
+  it("round-trips a token and recovers the claims", async () => {
+    const token = await signClawForgeJwt(CLAIMS, SECRET);
+    const payload = await verifyClawForgeJwt(token, SECRET);
+    expect(payload.userId).toBe("u1");
+    expect(payload.orgId).toBe("o1");
+    expect(payload.email).toBe("u1@example.com");
+    expect(payload.role).toBe("admin");
+  });
+
+  it("includes iat and exp claims", async () => {
+    const token = await signClawForgeJwt(CLAIMS, SECRET, { expiresInSec: 60 });
+    const payload = await verifyClawForgeJwt(token, SECRET);
+    expect(typeof payload.iat).toBe("number");
+    expect(typeof payload.exp).toBe("number");
+    expect(payload.exp! - payload.iat!).toBe(60);
+  });
+
+  it("rejects a token signed with a different secret", async () => {
+    const token = await signClawForgeJwt(CLAIMS, SECRET);
+    await expect(verifyClawForgeJwt(token, "different-secret-key")).rejects.toThrow();
+  });
+
+  it("rejects an expired token", async () => {
+    const token = await signClawForgeJwt(CLAIMS, SECRET, { expiresInSec: -10 });
+    await expect(verifyClawForgeJwt(token, SECRET)).rejects.toThrow();
+  });
+
+  it("enforces audience when provided", async () => {
+    const token = await signClawForgeJwt(CLAIMS, SECRET, { audience: "clawforge-control-plane" });
+    const ok = await verifyClawForgeJwt(token, SECRET, { audience: "clawforge-control-plane" });
+    expect(ok.userId).toBe("u1");
+    await expect(verifyClawForgeJwt(token, SECRET, { audience: "wrong-aud" })).rejects.toThrow();
+  });
+});
+
+describe("jwtClaimsToHumanIdentity", () => {
+  it("projects claims into a HumanIdentity shape", () => {
+    const identity = jwtClaimsToHumanIdentity({ ...CLAIMS, iat: 1, exp: 2 });
+    expect(identity).toEqual({
+      kind: "human",
+      userId: "u1",
+      orgId: "o1",
+      email: "u1@example.com",
+      role: "admin",
+    });
+  });
+});

--- a/packages/auth/src/jwt.ts
+++ b/packages/auth/src/jwt.ts
@@ -1,0 +1,96 @@
+import { TextEncoder } from "node:util";
+import { jwtVerify, SignJWT } from "jose";
+import type { HumanIdentity, HumanRole } from "./identities.js";
+
+/**
+ * Framework-free JWT helpers built on `jose`. The server today goes through
+ * `@fastify/jwt` (via `app.jwt.verify`); these helpers expose the same
+ * sign/verify operations without the Fastify dependency so plugin code,
+ * worker code, and tests can call them directly.
+ *
+ * Token claim shape mirrors what the server signs today: `{ userId, orgId,
+ * email, role }`. We expose the strict claim type for typed callers and a
+ * looser `unknown` form so adapters can refresh sessions without enforcing
+ * the shape themselves.
+ */
+
+export type ClawForgeJwtClaims = {
+  userId: string;
+  orgId: string;
+  email: string;
+  role: HumanRole;
+  /** Standard JWT claims that jose may add. */
+  iat?: number;
+  exp?: number;
+};
+
+const DEFAULT_ALG = "HS256";
+
+function toKey(secret: string | Uint8Array): Uint8Array {
+  return typeof secret === "string" ? new TextEncoder().encode(secret) : secret;
+}
+
+export type SignJwtOptions = {
+  /** Seconds until expiry. Defaults to 8 hours, matching the server today. */
+  expiresInSec?: number;
+  /** Algorithm. HS256 by default — same as `@fastify/jwt` defaults. */
+  algorithm?: "HS256" | "HS384" | "HS512";
+  /** Optional issuer / audience to embed. */
+  issuer?: string;
+  audience?: string;
+};
+
+/**
+ * Sign a ClawForge JWT. Designed for HS256 (shared secret) which is the
+ * server's current configuration; asymmetric algorithms are out of scope
+ * for this helper.
+ */
+export async function signClawForgeJwt(
+  claims: Omit<ClawForgeJwtClaims, "iat" | "exp">,
+  secret: string | Uint8Array,
+  options: SignJwtOptions = {},
+): Promise<string> {
+  const expiresInSec = options.expiresInSec ?? 8 * 60 * 60;
+  const builder = new SignJWT({ ...claims })
+    .setProtectedHeader({ alg: options.algorithm ?? DEFAULT_ALG })
+    .setIssuedAt()
+    .setExpirationTime(`${expiresInSec}s`);
+  if (options.issuer) builder.setIssuer(options.issuer);
+  if (options.audience) builder.setAudience(options.audience);
+  return builder.sign(toKey(secret));
+}
+
+export type VerifyJwtOptions = {
+  issuer?: string;
+  audience?: string;
+};
+
+/**
+ * Verify a ClawForge JWT. Returns the typed claims; throws (via jose) on
+ * invalid signature, expiry, or malformed payload.
+ */
+export async function verifyClawForgeJwt(
+  token: string,
+  secret: string | Uint8Array,
+  options: VerifyJwtOptions = {},
+): Promise<ClawForgeJwtClaims> {
+  const { payload } = await jwtVerify(token, toKey(secret), {
+    issuer: options.issuer,
+    audience: options.audience,
+  });
+  return payload as unknown as ClawForgeJwtClaims;
+}
+
+/**
+ * Project a verified JWT payload into a `HumanIdentity`. Useful for the
+ * server middleware refactor in PR #9.
+ */
+export function jwtClaimsToHumanIdentity(claims: ClawForgeJwtClaims): HumanIdentity {
+  return {
+    kind: "human",
+    userId: claims.userId,
+    orgId: claims.orgId,
+    email: claims.email,
+    role: claims.role,
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       '@clawforgeai/contracts':
         specifier: workspace:*
         version: link:../contracts
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
     devDependencies:
       '@types/node':
         specifier: ^25.6.0

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,6 +10,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "forceConsistentCasingInFileNames": true,
+    "types": ["node"],
     "declaration": true,
     "noEmit": true,
     "ignoreDeprecations": "6.0"


### PR DESCRIPTION
## Summary

PR #3 of the **Phase 1 platform refactor** (`docs/technical-strategy.md`). Lands `@clawforgeai/auth` — framework-free identity types, JWT helpers, and API-key parsing.

> **Stacked on [#205](https://github.com/ClawForgeAI/clawforge/pull/205) → [#204](https://github.com/ClawForgeAI/clawforge/pull/204).** Base branch is `feat/phase1-pr2-contracts`. Auto-retargets to main as the stack lands.

## What

| Module | Exports |
|---|---|
| `identities.ts` | `HumanIdentity`, `DeviceIdentity`, `RunnerIdentity`, `ServiceAccountIdentity`, `AgentInstanceIdentity`, `ClawForgeIdentity` union, `isHuman`/`isServiceAccount`/`isAgentInstance` guards, `HUMAN_ROLES` |
| `jwt.ts` | `signClawForgeJwt`, `verifyClawForgeJwt`, `jwtClaimsToHumanIdentity`, types `ClawForgeJwtClaims`/`SignJwtOptions`/`VerifyJwtOptions` |
| `api-key.ts` | `isApiKey`, `parseApiKey`, constants `API_KEY_LIVE_PREFIX`/`API_KEY_TEST_PREFIX`/`API_KEY_LOOKUP_PREFIX_LENGTH` |
| `index.ts` | re-exports above + `SessionTokens` from contracts |

Tooling:
- Added \`jose ^6.2.3\` to \`packages/auth/dependencies\` (matches the version the server pins).
- Added \`\"types\": [\"node\"]\` to \`tsconfig.base.json\` so Node-only globals (\`TextEncoder\` via \`node:util\`, etc.) typecheck in every package.

## Why

- Strategy doc calls for **identity separation**: humans, devices, runners, service accounts, agent instances are different trust models. Today the server collapses them all into one \`AuthUser\` shape.
- **Framework-free** — pure \`jose\`, not \`@fastify/jwt\`. Lets the plugin (no Fastify), workers, CLIs, and tests sign/verify directly.
- **API-key parsing extracted as a pure function** so the PR #9 server refactor can drop in \`parseApiKey()\` without changing the wire format. Format is byte-identical: \`cf_live_\` / \`cf_test_\` prefix, 16-char lookup index, bcrypt-verified.

## Test plan

- [x] \`pnpm --filter @clawforgeai/auth test\` — **19/19 pass** across 3 modules
  - identities: 4 guard-narrowing + role-enum-parity cases
  - jwt: 5 cases (round-trip, iat/exp, wrong-secret reject, expired reject, audience enforcement)
  - api-key: 9 cases (live/test classification, JWT shape rejection, 16-char lookup, token preservation)
- [x] \`pnpm --filter @clawforgeai/auth build\` — \`dist/index.js\` 2.25 KB, \`dist/index.d.ts\` 6.53 KB
- [x] \`pnpm -r --filter './packages/*' build\` — all 7 packages green
- [x] \`pnpm -r --filter './packages/*' typecheck\` — clean
- [x] \`pnpm check:deps\` — \`7 package(s) OK\` (DAG holds: auth → contracts, jose)
- [x] \`pnpm --filter @clawforgeai/clawforge test\` — **163/163 still green** (no regression)
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm format:check\` — only the 2 pre-existing files flagged

## Behavior preservation

Plugin, server, and admin don't import from \`@clawforgeai/auth\` yet — PR #9 wires the server middleware. No wire shapes, on-disk paths, or UX changes here.

## What's next

PR #4: \`feat(tool-governance): action taxonomy + tool groups + DLP scanner (move from plugin)\` (\`@clawforgeai/tool-governance\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)