### PR TITLE
feat(policy-engine): pure tool-call evaluator (Phase 1 #160)

### DIFF
--- a/packages/policy-engine/src/evaluate.test.ts
+++ b/packages/policy-engine/src/evaluate.test.ts
@@ -1,0 +1,374 @@
+import type { OrgPolicy } from "@clawforgeai/contracts";
+import { describe, expect, it } from "vitest";
+import { evaluateToolCall } from "./evaluate.js";
+import type { PolicyEvaluationContext } from "./types.js";
+
+function makePolicy(overrides?: Partial<OrgPolicy>): OrgPolicy {
+  return {
+    version: 1,
+    tools: {},
+    skills: { approved: [], requireApproval: false },
+    killSwitch: { active: false },
+    auditLevel: "metadata",
+    ...overrides,
+  };
+}
+
+function makeCtx(overrides?: Partial<PolicyEvaluationContext>): PolicyEvaluationContext {
+  return {
+    policy: null,
+    killSwitchActive: false,
+    ...overrides,
+  };
+}
+
+describe("evaluateToolCall", () => {
+  describe("kill switch", () => {
+    it("denies any tool with the configured message", () => {
+      const ctx = makeCtx({ killSwitchActive: true, killSwitchMessage: "Emergency shutdown" });
+      const decision = evaluateToolCall(ctx, { rawToolName: "exec", params: {} });
+
+      expect(decision).toMatchObject({
+        outcome: "deny",
+        reason: "kill_switch",
+        blockMessage: "Emergency shutdown",
+      });
+    });
+
+    it("kill switch overrides offlineOverride='allow'", () => {
+      const ctx = makeCtx({
+        killSwitchActive: true,
+        killSwitchMessage: "Emergency shutdown",
+        offlineOverride: "allow",
+      });
+      const decision = evaluateToolCall(ctx, { rawToolName: "exec", params: {} });
+
+      expect(decision.outcome).toBe("deny");
+      expect(decision.reason).toBe("kill_switch");
+    });
+
+    it("kill switch overrides offlineOverride='cached'", () => {
+      const ctx = makeCtx({
+        killSwitchActive: true,
+        killSwitchMessage: "Emergency shutdown",
+        offlineOverride: "cached",
+        policy: makePolicy(),
+      });
+      const decision = evaluateToolCall(ctx, { rawToolName: "read", params: {} });
+
+      expect(decision.outcome).toBe("deny");
+      expect(decision.reason).toBe("kill_switch");
+    });
+
+    it("uses default message when killSwitchMessage is undefined", () => {
+      const ctx = makeCtx({ killSwitchActive: true });
+      const decision = evaluateToolCall(ctx, { rawToolName: "read", params: {} });
+
+      expect(decision.outcome).toBe("deny");
+      expect(decision.blockMessage).toContain("kill switch");
+    });
+  });
+
+  describe("pendingInit safe mode", () => {
+    it("denies tools when pendingInit is true and no policy cached", () => {
+      const ctx = makeCtx({ pendingInit: true });
+      const decision = evaluateToolCall(ctx, { rawToolName: "read", params: {} });
+
+      expect(decision).toMatchObject({
+        outcome: "deny",
+        reason: "pending_init",
+        blockMessage: "ClawForge: Plugin is still initializing. Please try again shortly.",
+      });
+    });
+
+    it("evaluates normally when pendingInit is true but a policy is loaded", () => {
+      const ctx = makeCtx({ pendingInit: true, policy: makePolicy() });
+      const decision = evaluateToolCall(ctx, { rawToolName: "read", params: {} });
+
+      expect(decision.outcome).toBe("allow");
+      expect(decision.reason).toBe("allowed");
+    });
+  });
+
+  describe("offline modes", () => {
+    it("offlineOverride='allow' short-circuits to allow without consulting policy", () => {
+      const ctx = makeCtx({
+        offlineOverride: "allow",
+        policy: makePolicy({ tools: { deny: ["exec"] } }),
+      });
+      const decision = evaluateToolCall(ctx, { rawToolName: "exec", params: {} });
+
+      expect(decision).toMatchObject({ outcome: "allow", reason: "offline_allow_mode" });
+    });
+
+    it("offlineOverride='cached' tags decision with mode but still enforces", () => {
+      const ctx = makeCtx({
+        offlineOverride: "cached",
+        policy: makePolicy({ tools: { deny: ["exec"] } }),
+      });
+      const decision = evaluateToolCall(ctx, { rawToolName: "exec", params: {} });
+
+      expect(decision).toMatchObject({
+        outcome: "deny",
+        reason: "deny_list",
+        mode: "offline_cached_mode",
+      });
+    });
+  });
+
+  describe("no policy", () => {
+    it("allows by default when policy is null", () => {
+      const decision = evaluateToolCall(makeCtx(), { rawToolName: "exec", params: {} });
+      expect(decision).toMatchObject({ outcome: "allow", reason: "no_policy" });
+    });
+  });
+
+  describe("deny list", () => {
+    it("denies a tool listed in deny", () => {
+      const ctx = makeCtx({ policy: makePolicy({ tools: { deny: ["exec", "write"] } }) });
+      const decision = evaluateToolCall(ctx, { rawToolName: "exec", params: {} });
+
+      expect(decision).toMatchObject({
+        outcome: "deny",
+        reason: "deny_list",
+        blockMessage: 'ClawForge: Tool "exec" is blocked by organization policy',
+      });
+    });
+
+    it("allows a tool not in deny", () => {
+      const ctx = makeCtx({ policy: makePolicy({ tools: { deny: ["exec"] } }) });
+      const decision = evaluateToolCall(ctx, { rawToolName: "read", params: {} });
+
+      expect(decision.outcome).toBe("allow");
+    });
+
+    it("expands tool groups in deny list", () => {
+      const ctx = makeCtx({ policy: makePolicy({ tools: { deny: ["group:runtime"] } }) });
+
+      expect(evaluateToolCall(ctx, { rawToolName: "exec", params: {} }).outcome).toBe("deny");
+      expect(evaluateToolCall(ctx, { rawToolName: "process", params: {} }).outcome).toBe("deny");
+      expect(evaluateToolCall(ctx, { rawToolName: "read", params: {} }).outcome).toBe("allow");
+    });
+
+    it("normalizes alias bash -> exec", () => {
+      const ctx = makeCtx({ policy: makePolicy({ tools: { deny: ["exec"] } }) });
+      const decision = evaluateToolCall(ctx, { rawToolName: "bash", params: {} });
+
+      expect(decision.outcome).toBe("deny");
+      // raw name preserved in user-facing message
+      expect(decision.blockMessage).toContain('"bash"');
+    });
+  });
+
+  describe("allow list", () => {
+    it("allows tools in the allow list", () => {
+      const ctx = makeCtx({ policy: makePolicy({ tools: { allow: ["read", "write"] } }) });
+      expect(evaluateToolCall(ctx, { rawToolName: "read", params: {} }).outcome).toBe("allow");
+    });
+
+    it("denies tools not in the allow list", () => {
+      const ctx = makeCtx({ policy: makePolicy({ tools: { allow: ["read", "write"] } }) });
+      const decision = evaluateToolCall(ctx, { rawToolName: "exec", params: {} });
+
+      expect(decision).toMatchObject({
+        outcome: "deny",
+        reason: "not_in_allowlist",
+        blockMessage: 'ClawForge: Tool "exec" is not in the organization\'s allowed tools list',
+      });
+    });
+
+    it("expands tool groups in allow list", () => {
+      const ctx = makeCtx({ policy: makePolicy({ tools: { allow: ["group:fs"] } }) });
+
+      expect(evaluateToolCall(ctx, { rawToolName: "read", params: {} }).outcome).toBe("allow");
+      expect(evaluateToolCall(ctx, { rawToolName: "write", params: {} }).outcome).toBe("allow");
+      expect(evaluateToolCall(ctx, { rawToolName: "edit", params: {} }).outcome).toBe("allow");
+      expect(evaluateToolCall(ctx, { rawToolName: "exec", params: {} }).outcome).toBe("deny");
+    });
+  });
+
+  describe("deny overrides allow", () => {
+    it("denies a tool that appears in both allow and deny", () => {
+      const ctx = makeCtx({
+        policy: makePolicy({ tools: { allow: ["read", "exec"], deny: ["exec"] } }),
+      });
+      const decision = evaluateToolCall(ctx, { rawToolName: "exec", params: {} });
+
+      expect(decision.outcome).toBe("deny");
+      expect(decision.reason).toBe("deny_list");
+    });
+  });
+
+  describe("fs deny blocks exec filesystem commands", () => {
+    const ctx = makeCtx({ policy: makePolicy({ tools: { deny: ["group:fs"] } }) });
+
+    it("blocks ls when group:fs is denied", () => {
+      const decision = evaluateToolCall(ctx, { rawToolName: "exec", params: { command: "ls ~/Documents" } });
+      expect(decision).toMatchObject({ outcome: "deny", reason: "fs_deny_exec" });
+      expect(decision.blockMessage).toContain("filesystem access is denied");
+    });
+
+    it("blocks cat when 'read' is explicitly denied", () => {
+      const localCtx = makeCtx({ policy: makePolicy({ tools: { deny: ["read"] } }) });
+      const decision = evaluateToolCall(localCtx, { rawToolName: "exec", params: { command: "cat /etc/passwd" } });
+      expect(decision.outcome).toBe("deny");
+      expect(decision.reason).toBe("fs_deny_exec");
+    });
+
+    it("blocks find when group:fs is denied", () => {
+      const decision = evaluateToolCall(ctx, { rawToolName: "exec", params: { command: "find / -name '*.txt'" } });
+      expect(decision.outcome).toBe("deny");
+    });
+
+    it("blocks piped fs commands", () => {
+      const decision = evaluateToolCall(ctx, {
+        rawToolName: "exec",
+        params: { command: "echo hello | cat > /tmp/test" },
+      });
+      expect(decision.outcome).toBe("deny");
+    });
+
+    it("blocks cp and mv", () => {
+      expect(evaluateToolCall(ctx, { rawToolName: "exec", params: { command: "cp a b" } }).outcome).toBe("deny");
+      expect(evaluateToolCall(ctx, { rawToolName: "exec", params: { command: "mv a b" } }).outcome).toBe("deny");
+    });
+
+    it("allows echo (non-fs command) when group:fs is denied", () => {
+      const decision = evaluateToolCall(ctx, { rawToolName: "exec", params: { command: "echo hello" } });
+      expect(decision.outcome).toBe("allow");
+    });
+
+    it("allows exec when only unrelated tools are denied", () => {
+      const otherCtx = makeCtx({ policy: makePolicy({ tools: { deny: ["web_search"] } }) });
+      const decision = evaluateToolCall(otherCtx, { rawToolName: "exec", params: { command: "ls /" } });
+      expect(decision.outcome).toBe("allow");
+    });
+
+    it("blocks sudo-prefixed fs commands", () => {
+      const decision = evaluateToolCall(ctx, { rawToolName: "exec", params: { command: "sudo ls /root" } });
+      expect(decision.outcome).toBe("deny");
+    });
+
+    it("exposes the offending command via blockedCommand", () => {
+      const decision = evaluateToolCall(ctx, { rawToolName: "exec", params: { command: "ls /" } });
+      expect(decision.blockedCommand).toBe("ls /");
+    });
+  });
+
+  describe("DLP", () => {
+    const dlpPolicy = makePolicy({
+      dlpRules: [
+        {
+          name: "ssn",
+          pattern: "\\b\\d{3}-\\d{2}-\\d{4}\\b",
+          action: "block",
+          severity: "high",
+        },
+      ],
+    });
+
+    it("denies when a block-action rule matches", () => {
+      const ctx = makeCtx({ policy: dlpPolicy });
+      const decision = evaluateToolCall(ctx, {
+        rawToolName: "write",
+        params: { content: "user ssn 123-45-6789" },
+      });
+
+      expect(decision).toMatchObject({
+        outcome: "deny",
+        reason: "dlp_block",
+      });
+      expect(decision.blockMessage).toContain("sensitive data detected");
+      expect(decision.dlp?.violations).toHaveLength(1);
+      expect(decision.dlp?.effectiveAction).toBe("block");
+    });
+
+    it("allows but reports violations for warn-only rules", () => {
+      const warnPolicy = makePolicy({
+        dlpRules: [
+          {
+            name: "phone",
+            pattern: "\\b\\d{3}-\\d{3}-\\d{4}\\b",
+            action: "warn",
+            severity: "medium",
+          },
+        ],
+      });
+      const ctx = makeCtx({ policy: warnPolicy });
+      const decision = evaluateToolCall(ctx, {
+        rawToolName: "write",
+        params: { content: "call 555-123-4567" },
+      });
+
+      expect(decision).toMatchObject({
+        outcome: "allow",
+        reason: "dlp_violation_allowed",
+      });
+      expect(decision.dlp?.violations).toHaveLength(1);
+      expect(decision.dlp?.effectiveAction).toBe("warn");
+    });
+
+    it("DLP runs after allow-list passes, not before", () => {
+      const restrictivePolicy = makePolicy({
+        tools: { allow: ["read"] },
+        dlpRules: [
+          {
+            name: "ssn",
+            pattern: "\\d{3}-\\d{2}-\\d{4}",
+            action: "block",
+            severity: "high",
+          },
+        ],
+      });
+      const ctx = makeCtx({ policy: restrictivePolicy });
+      // write is not in allow list — should fail with not_in_allowlist, not dlp_block.
+      const decision = evaluateToolCall(ctx, {
+        rawToolName: "write",
+        params: { content: "123-45-6789" },
+      });
+
+      expect(decision.reason).toBe("not_in_allowlist");
+    });
+  });
+
+  describe("offline_cached mode tagging", () => {
+    it("tags `mode` on no_policy outcomes", () => {
+      const ctx = makeCtx({ offlineOverride: "cached" });
+      const decision = evaluateToolCall(ctx, { rawToolName: "exec", params: {} });
+
+      expect(decision.outcome).toBe("allow");
+      expect(decision.reason).toBe("no_policy");
+      expect(decision.mode).toBe("offline_cached_mode");
+    });
+
+    it("tags `mode` on allowed outcomes", () => {
+      const ctx = makeCtx({ offlineOverride: "cached", policy: makePolicy() });
+      const decision = evaluateToolCall(ctx, { rawToolName: "read", params: {} });
+
+      expect(decision.outcome).toBe("allow");
+      expect(decision.mode).toBe("offline_cached_mode");
+    });
+
+    it("tags `mode` on fs_deny_exec outcomes", () => {
+      const ctx = makeCtx({
+        offlineOverride: "cached",
+        policy: makePolicy({ tools: { deny: ["group:fs"] } }),
+      });
+      const decision = evaluateToolCall(ctx, { rawToolName: "exec", params: { command: "ls /" } });
+
+      expect(decision.reason).toBe("fs_deny_exec");
+      expect(decision.mode).toBe("offline_cached_mode");
+    });
+
+    it("tags `mode` on not_in_allowlist outcomes", () => {
+      const ctx = makeCtx({
+        offlineOverride: "cached",
+        policy: makePolicy({ tools: { allow: ["read"] } }),
+      });
+      const decision = evaluateToolCall(ctx, { rawToolName: "exec", params: {} });
+
+      expect(decision.reason).toBe("not_in_allowlist");
+      expect(decision.mode).toBe("offline_cached_mode");
+    });
+  });
+});

--- a/packages/policy-engine/src/evaluate.ts
+++ b/packages/policy-engine/src/evaluate.ts
@@ -1,0 +1,125 @@
+import type { OrgPolicy } from "@clawforgeai/contracts";
+import {
+  expandGroups,
+  isExecBlockedByFsDeny,
+  normalizeToolName,
+  scanToolArguments,
+} from "@clawforgeai/tool-governance";
+import type { PolicyDecision, PolicyEvaluationContext, ToolCallEvaluationInput } from "./types.js";
+
+const KILL_SWITCH_DEFAULT_MESSAGE = "ClawForge: All tool calls blocked by organization kill switch";
+
+/**
+ * Evaluate a single tool call against the current policy and runtime state.
+ *
+ * Pure function — no I/O, no logging. Callers (plugin hook, stateless
+ * enforce endpoint, admin preview) decide what to do with the decision.
+ *
+ * Precedence order (matches the legacy `plugin/src/policy/tool-enforcer.ts`
+ * exactly — covered by snapshot tests against the existing plugin suite):
+ *   1. pendingInit + no policy -> deny pending_init
+ *   2. killSwitchActive       -> deny kill_switch (overrides offline mode)
+ *   3. offlineOverride='allow' -> allow offline_allow_mode
+ *   4. offlineOverride='cached'-> evaluate against cached policy, mode tagged
+ *   5. normal policy evaluation
+ */
+export function evaluateToolCall(ctx: PolicyEvaluationContext, input: ToolCallEvaluationInput): PolicyDecision {
+  const toolName = normalizeToolName(input.rawToolName);
+
+  if (ctx.pendingInit && !ctx.policy) {
+    return {
+      outcome: "deny",
+      reason: "pending_init",
+      blockMessage: "ClawForge: Plugin is still initializing. Please try again shortly.",
+    };
+  }
+
+  if (ctx.killSwitchActive) {
+    return {
+      outcome: "deny",
+      reason: "kill_switch",
+      blockMessage: ctx.killSwitchMessage ?? KILL_SWITCH_DEFAULT_MESSAGE,
+    };
+  }
+
+  if (ctx.offlineOverride === "allow") {
+    return { outcome: "allow", reason: "offline_allow_mode" };
+  }
+
+  const mode = ctx.offlineOverride === "cached" ? ("offline_cached_mode" as const) : undefined;
+  return evaluatePolicy(ctx.policy, toolName, input, mode);
+}
+
+function evaluatePolicy(
+  policy: OrgPolicy | null,
+  toolName: string,
+  input: ToolCallEvaluationInput,
+  mode: "offline_cached_mode" | undefined,
+): PolicyDecision {
+  if (!policy) {
+    return { outcome: "allow", reason: "no_policy", mode };
+  }
+
+  if (policy.tools.deny && policy.tools.deny.length > 0) {
+    const denySet = expandGroups(policy.tools.deny);
+
+    if (denySet.has(toolName)) {
+      return {
+        outcome: "deny",
+        reason: "deny_list",
+        mode,
+        blockMessage: `ClawForge: Tool "${input.rawToolName}" is blocked by organization policy`,
+      };
+    }
+
+    if (toolName === "exec" && isExecBlockedByFsDeny(denySet, input.params)) {
+      const command = (input.params.command ?? input.params.cmd ?? "") as string;
+      return {
+        outcome: "deny",
+        reason: "fs_deny_exec",
+        mode,
+        blockedCommand: command,
+        blockMessage: "ClawForge: Shell command blocked — filesystem access is denied by organization policy",
+      };
+    }
+  }
+
+  if (policy.tools.allow && policy.tools.allow.length > 0) {
+    const allowSet = expandGroups(policy.tools.allow);
+    if (!allowSet.has(toolName)) {
+      return {
+        outcome: "deny",
+        reason: "not_in_allowlist",
+        mode,
+        blockMessage: `ClawForge: Tool "${input.rawToolName}" is not in the organization's allowed tools list`,
+      };
+    }
+  }
+
+  if (policy.dlpRules && policy.dlpRules.length > 0) {
+    const dlpResult = scanToolArguments(policy.dlpRules, input.params);
+
+    if (dlpResult.violations.length > 0) {
+      if (dlpResult.effectiveAction === "block") {
+        const blockingRules = dlpResult.violations.filter((v) => v.action === "block");
+        const ruleNames = blockingRules.map((v) => v.ruleName).join(", ");
+        return {
+          outcome: "deny",
+          reason: "dlp_block",
+          mode,
+          dlp: dlpResult,
+          blockMessage: `ClawForge DLP: Tool call blocked — sensitive data detected (rules: ${ruleNames})`,
+        };
+      }
+
+      return {
+        outcome: "allow",
+        reason: "dlp_violation_allowed",
+        mode,
+        dlp: dlpResult,
+      };
+    }
+  }
+
+  return { outcome: "allow", reason: "allowed", mode };
+}

--- a/packages/policy-engine/src/index.test.ts
+++ b/packages/policy-engine/src/index.test.ts
@@ -1,8 +1,0 @@
-import { describe, expect, it } from "vitest";
-import { PACKAGE_NAME } from "./index.js";
-
-describe("@clawforgeai/policy-engine", () => {
-  it("exports PACKAGE_NAME", () => {
-    expect(PACKAGE_NAME).toBe("@clawforgeai/policy-engine");
-  });
-});

--- a/packages/policy-engine/src/index.ts
+++ b/packages/policy-engine/src/index.ts
@@ -1,1 +1,4 @@
 export const PACKAGE_NAME = "@clawforgeai/policy-engine";
+
+export * from "./types.js";
+export { evaluateToolCall } from "./evaluate.js";

--- a/packages/policy-engine/src/types.ts
+++ b/packages/policy-engine/src/types.ts
@@ -1,0 +1,65 @@
+import type { DlpScanResult, OrgPolicy } from "@clawforgeai/contracts";
+
+export type PolicyOutcome = "allow" | "deny";
+
+/**
+ * Why the policy engine arrived at its decision. Mirrors the audit-log
+ * reason strings emitted by the plugin's tool-enforcer hook so that
+ * existing audit consumers see no behavior change after the extraction.
+ */
+export type PolicyDecisionReason =
+  | "pending_init"
+  | "kill_switch"
+  | "offline_allow_mode"
+  | "no_policy"
+  | "deny_list"
+  | "fs_deny_exec"
+  | "not_in_allowlist"
+  | "dlp_block"
+  | "dlp_violation_allowed"
+  | "allowed";
+
+/**
+ * Offline mode in effect at the moment of evaluation. Surfaced separately
+ * from `reason` so callers can compose audit metadata (e.g. the plugin
+ * suffixes "(offline_cached_mode)" onto reason strings).
+ */
+export type PolicyEvaluationMode = "offline_cached_mode";
+
+export interface PolicyDecision {
+  outcome: PolicyOutcome;
+  reason: PolicyDecisionReason;
+  mode?: PolicyEvaluationMode;
+  /** Shell command string that triggered fs_deny_exec, for audit context. */
+  blockedCommand?: string;
+  /** DLP scan result if a scan ran. Present on both allow and deny outcomes. */
+  dlp?: DlpScanResult;
+  /**
+   * User-facing block reason. Stable wording matching the plugin's previous
+   * messages — surfaced via `PluginHookBeforeToolCallResult.blockReason`.
+   * Only set when `outcome === "deny"`.
+   */
+  blockMessage?: string;
+}
+
+export interface PolicyEvaluationContext {
+  policy: OrgPolicy | null;
+  killSwitchActive: boolean;
+  killSwitchMessage?: string;
+  /**
+   * Offline override set by the KillSwitchManager when the failure threshold
+   * is reached. `undefined` means normal enforcement.
+   */
+  offlineOverride?: "allow" | "cached";
+  /**
+   * True while initializeClawForge() is still running. When true and no
+   * policy is cached, every tool call is blocked as a safe-mode default.
+   */
+  pendingInit?: boolean;
+}
+
+export interface ToolCallEvaluationInput {
+  /** Tool name as received from the runtime (may need normalization, e.g. "bash"). */
+  rawToolName: string;
+  params: Record<string, unknown>;
+}


### PR DESCRIPTION
## What changed

Implements \`@clawforgeai/policy-engine\` as a pure decision function:

\`\`\`ts
evaluateToolCall(ctx, input) -> PolicyDecision
\`\`\`

No I/O, no audit logging — callers (plugin hook, future stateless enforce endpoint, admin policy preview) translate the decision into their own side effects.

**Precedence order** matches \`plugin/src/policy/tool-enforcer.ts\` byte-for-byte:
1. \`pendingInit\` (no cached policy) → \`pending_init\`
2. \`killSwitchActive\` → \`kill_switch\` (overrides offline mode)
3. \`offlineOverride='allow'\` → short-circuit allow
4. \`offlineOverride='cached'\` → evaluate, tag \`mode: offline_cached_mode\`
5. Deny list (with group expansion + bash→exec normalization)
6. \`fs_deny_exec\` shell-bypass check
7. Allow list (with group expansion)
8. DLP scan (block | warn-and-allow)
9. Default allow

## Why

Phase 1 (\`docs/technical-strategy.md\`) extracts shared platform primitives so plugin, server, and admin can call one policy engine. This PR ships the package only — the plugin still uses its inline tool-enforcer. A follow-up PR (#147, the plugin refactor) will swap it.

## How to test

- [x] \`pnpm --filter @clawforgeai/policy-engine test\` — **33 tests pass** (parity snapshot of \`tool-enforcer.test.ts\`)
- [x] \`pnpm --filter @clawforgeai/policy-engine build\` — clean
- [x] \`pnpm --filter @clawforgeai/policy-engine typecheck\` — clean
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm format:check\` — clean

## Parity contract

Tests cover the same scenarios as \`plugin/src/policy/tool-enforcer.test.ts\`:
- kill switch precedence (including offline override interactions)
- pendingInit safe mode
- no policy / deny list / allow list / deny-overrides-allow
- group expansion (\`group:fs\`, \`group:runtime\`)
- bash → exec normalization
- fs-deny-exec for ls/cat/find/cp/mv/sudo + piped commands
- DLP block vs warn-allow, and DLP-after-allow-list ordering
- \`offline_cached_mode\` tagging on all decision branches

The plugin refactor PR will reuse the existing \`tool-enforcer.test.ts\` as the binding contract.

## Checklist

- [x] No changes to plugin/server/admin (extraction only)
- [x] Pure function — no I/O, no logging
- [x] Imports stay one-way: \`policy-engine\` → \`contracts\` + \`tool-governance\`