### PR TITLE
feat(audit-events): batched queue + JSONL serialization (Phase 1 #161)

### DIFF
--- a/packages/audit-events/src/index.test.ts
+++ b/packages/audit-events/src/index.test.ts
@@ -1,8 +1,0 @@
-import { describe, expect, it } from "vitest";
-import { PACKAGE_NAME } from "./index.js";
-
-describe("@clawforgeai/audit-events", () => {
-  it("exports PACKAGE_NAME", () => {
-    expect(PACKAGE_NAME).toBe("@clawforgeai/audit-events");
-  });
-});

--- a/packages/audit-events/src/index.ts
+++ b/packages/audit-events/src/index.ts
@@ -1,1 +1,5 @@
 export const PACKAGE_NAME = "@clawforgeai/audit-events";
+
+export * from "./types.js";
+export { BatchedAuditQueue } from "./queue.js";
+export { serializeJsonl, parseJsonl } from "./serialize.js";

--- a/packages/audit-events/src/queue.test.ts
+++ b/packages/audit-events/src/queue.test.ts
@@ -1,0 +1,246 @@
+import type { AuditEvent } from "@clawforgeai/contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BatchedAuditQueue } from "./queue.js";
+import type { AuditPersistence, AuditTransport, BatchedAuditQueueOptions } from "./types.js";
+
+function makeQueue(overrides?: Partial<BatchedAuditQueueOptions>): {
+  queue: BatchedAuditQueue;
+  transport: ReturnType<typeof vi.fn> & AuditTransport;
+  persistence: { load: ReturnType<typeof vi.fn>; save: ReturnType<typeof vi.fn>; clear: ReturnType<typeof vi.fn> };
+  logger: { info: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
+} {
+  const transport = vi.fn(async () => true) as ReturnType<typeof vi.fn> & AuditTransport;
+  const persistence = {
+    load: vi.fn(() => [] as AuditEvent[]),
+    save: vi.fn(),
+    clear: vi.fn(),
+  } satisfies AuditPersistence;
+  const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+  const queue = new BatchedAuditQueue({
+    identity: { userId: "u1", orgId: "o1" },
+    transport,
+    persistence,
+    logger,
+    auditLevel: "full",
+    batchSize: 100,
+    maxBufferSize: 10_000,
+    now: () => 1_700_000_000_000,
+    ...overrides,
+  });
+
+  return { queue, transport, persistence, logger };
+}
+
+describe("BatchedAuditQueue", () => {
+  describe("enqueue", () => {
+    it("attaches identity, timestamp, and outcome to each event", () => {
+      const { queue, transport } = makeQueue();
+
+      queue.enqueue({ eventType: "tool_call_attempt", outcome: "allowed", toolName: "read" });
+
+      expect(queue.bufferSize).toBe(1);
+      // flush to see the event that goes to transport
+      return queue.flush().then(() => {
+        expect(transport).toHaveBeenCalledWith([
+          expect.objectContaining({
+            userId: "u1",
+            orgId: "o1",
+            eventType: "tool_call_attempt",
+            outcome: "allowed",
+            toolName: "read",
+            timestamp: 1_700_000_000_000,
+          }),
+        ]);
+      });
+    });
+
+    it("no-ops when auditLevel is 'off'", () => {
+      const { queue, transport } = makeQueue({ auditLevel: "off" });
+      queue.enqueue({ eventType: "tool_call_attempt", outcome: "allowed" });
+      expect(queue.bufferSize).toBe(0);
+      return queue.flush().then(() => expect(transport).not.toHaveBeenCalled());
+    });
+
+    it("drops metadata when auditLevel is 'metadata'", async () => {
+      const { queue, transport } = makeQueue({ auditLevel: "metadata" });
+      queue.enqueue({
+        eventType: "tool_call_attempt",
+        outcome: "blocked",
+        metadata: { reason: "deny_list" },
+      });
+      await queue.flush();
+      expect(transport.mock.calls[0]?.[0][0].metadata).toBeUndefined();
+    });
+
+    it("preserves metadata when auditLevel is 'full'", async () => {
+      const { queue, transport } = makeQueue();
+      queue.enqueue({
+        eventType: "tool_call_attempt",
+        outcome: "blocked",
+        metadata: { reason: "deny_list" },
+      });
+      await queue.flush();
+      expect(transport.mock.calls[0]?.[0][0].metadata).toEqual({ reason: "deny_list" });
+    });
+
+    it("setAuditLevel updates behavior at runtime", async () => {
+      const { queue, transport } = makeQueue({ auditLevel: "full" });
+      queue.setAuditLevel("off");
+      queue.enqueue({ eventType: "tool_call_attempt", outcome: "allowed" });
+      await queue.flush();
+      expect(transport).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("overflow", () => {
+    it("drops oldest events when bufferSize exceeds maxBufferSize", () => {
+      const { queue, logger } = makeQueue({ maxBufferSize: 3, warningThreshold: 0.99 });
+      for (let i = 0; i < 5; i++) {
+        queue.enqueue({ eventType: "tool_call_attempt", outcome: "allowed", toolName: `t${i}` });
+      }
+      expect(queue.bufferSize).toBe(3);
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Dropped"));
+    });
+
+    it("emits a single capacity warning once per cycle when over threshold", () => {
+      const { queue, logger } = makeQueue({ maxBufferSize: 10, warningThreshold: 0.5 });
+      for (let i = 0; i < 6; i++) {
+        queue.enqueue({ eventType: "tool_call_attempt", outcome: "allowed" });
+      }
+      const warns = logger.warn.mock.calls.filter((args) =>
+        String(args[0]).startsWith("Audit buffer approaching capacity"),
+      );
+      expect(warns).toHaveLength(1);
+    });
+  });
+
+  describe("shouldFlush", () => {
+    it("returns true once batchSize is reached", () => {
+      const { queue } = makeQueue({ batchSize: 3 });
+      queue.enqueue({ eventType: "tool_call_attempt", outcome: "allowed" });
+      queue.enqueue({ eventType: "tool_call_attempt", outcome: "allowed" });
+      expect(queue.shouldFlush()).toBe(false);
+      queue.enqueue({ eventType: "tool_call_attempt", outcome: "allowed" });
+      expect(queue.shouldFlush()).toBe(true);
+    });
+  });
+
+  describe("flush", () => {
+    it("calls transport with the drained batch and clears persistence on success", async () => {
+      const { queue, transport, persistence } = makeQueue();
+      queue.enqueue({ eventType: "tool_call_attempt", outcome: "allowed" });
+      queue.enqueue({ eventType: "tool_call_attempt", outcome: "blocked" });
+
+      await queue.flush();
+
+      expect(transport).toHaveBeenCalledTimes(1);
+      expect(transport.mock.calls[0]?.[0]).toHaveLength(2);
+      expect(queue.bufferSize).toBe(0);
+      expect(persistence.clear).toHaveBeenCalledTimes(1);
+      expect(persistence.save).not.toHaveBeenCalled();
+    });
+
+    it("requeues the batch and persists on transport failure", async () => {
+      const { queue, transport, persistence } = makeQueue();
+      transport.mockResolvedValueOnce(false);
+
+      queue.enqueue({ eventType: "tool_call_attempt", outcome: "allowed" });
+      await queue.flush();
+
+      expect(queue.bufferSize).toBe(1);
+      expect(persistence.save).toHaveBeenCalledTimes(1);
+      expect(persistence.clear).not.toHaveBeenCalled();
+    });
+
+    it("treats thrown transports as failure and persists", async () => {
+      const { queue, persistence, logger, transport } = makeQueue();
+      transport.mockRejectedValueOnce(new Error("network"));
+
+      queue.enqueue({ eventType: "tool_call_attempt", outcome: "allowed" });
+      await queue.flush();
+
+      expect(queue.bufferSize).toBe(1);
+      expect(persistence.save).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("Audit transport threw"));
+    });
+
+    it("is a no-op on an empty buffer", async () => {
+      const { queue, transport } = makeQueue();
+      await queue.flush();
+      expect(transport).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("persistence reload", () => {
+    it("loads events from persistence on construction", () => {
+      const load = vi.fn(
+        () =>
+          [
+            {
+              userId: "u1",
+              orgId: "o1",
+              eventType: "tool_call_attempt",
+              outcome: "allowed",
+              timestamp: 1,
+            },
+          ] as AuditEvent[],
+      );
+      const queue = new BatchedAuditQueue({
+        identity: { userId: "u1", orgId: "o1" },
+        transport: async () => true,
+        persistence: { load, save: vi.fn(), clear: vi.fn() },
+      });
+
+      expect(load).toHaveBeenCalledTimes(1);
+      expect(queue.bufferSize).toBe(1);
+    });
+
+    it("trims reloaded buffer to maxBufferSize", () => {
+      const reload: AuditEvent[] = Array.from({ length: 5 }, (_, i) => ({
+        userId: "u1",
+        orgId: "o1",
+        eventType: "tool_call_attempt",
+        outcome: "allowed",
+        timestamp: i,
+      }));
+      const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      const queue = new BatchedAuditQueue({
+        identity: { userId: "u1", orgId: "o1" },
+        transport: async () => true,
+        persistence: { load: () => reload, save: vi.fn(), clear: vi.fn() },
+        maxBufferSize: 2,
+        logger,
+      });
+
+      expect(queue.bufferSize).toBe(2);
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("trimmed"));
+    });
+  });
+
+  describe("reset", () => {
+    let queue: BatchedAuditQueue;
+    let clear: () => void;
+
+    beforeEach(() => {
+      clear = vi.fn(() => undefined);
+      const persistence: AuditPersistence = {
+        load: () => [],
+        save: vi.fn(),
+        clear,
+      };
+      queue = new BatchedAuditQueue({
+        identity: { userId: "u1", orgId: "o1" },
+        transport: async () => true,
+        persistence,
+      });
+      queue.enqueue({ eventType: "tool_call_attempt", outcome: "allowed" });
+    });
+
+    it("drops buffered events and clears persistence", () => {
+      queue.reset();
+      expect(queue.bufferSize).toBe(0);
+      expect(clear).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/audit-events/src/queue.ts
+++ b/packages/audit-events/src/queue.ts
@@ -1,0 +1,166 @@
+import type { AuditEvent } from "@clawforgeai/contracts";
+import type {
+  AuditEventDraft,
+  AuditIdentity,
+  AuditLevel,
+  AuditLoggerSink,
+  AuditPersistence,
+  AuditTransport,
+  BatchedAuditQueueOptions,
+} from "./types.js";
+
+const DEFAULT_BATCH_SIZE = 100;
+const DEFAULT_MAX_BUFFER_SIZE = 10_000;
+const DEFAULT_WARNING_THRESHOLD = 0.8;
+
+/**
+ * Bounded in-memory audit queue with bulk flush, drop-oldest overflow,
+ * and optional durable persistence. Pure of any transport or file-system
+ * coupling — callers inject `transport` and `persistence`.
+ *
+ * Behavior mirrors the legacy `plugin/src/audit/audit-logger.ts`:
+ *   - `auditLevel === "off"` short-circuits enqueue
+ *   - `auditLevel === "metadata"` drops the per-event `metadata` payload
+ *   - the queue auto-flushes once `buffer.length >= batchSize`
+ *   - exceeding `maxBufferSize` evicts the oldest events with a warning
+ *   - failed transport puts the batch back on the head of the buffer and
+ *     checkpoints to persistence; successful transport clears persistence
+ *   - a capacity warning fires once per cycle above `warningThreshold`
+ */
+export class BatchedAuditQueue {
+  private readonly identity: AuditIdentity;
+  private readonly transport: AuditTransport;
+  private readonly persistence?: AuditPersistence;
+  private readonly logger?: AuditLoggerSink;
+  private readonly batchSize: number;
+  private readonly maxBufferSize: number;
+  private readonly warningThreshold: number;
+  private readonly now: () => number;
+
+  private buffer: AuditEvent[] = [];
+  private auditLevel: AuditLevel;
+  private hasWarnedCapacity = false;
+
+  constructor(options: BatchedAuditQueueOptions) {
+    this.identity = options.identity;
+    this.transport = options.transport;
+    this.persistence = options.persistence;
+    this.logger = options.logger;
+    this.auditLevel = options.auditLevel ?? "metadata";
+    this.batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
+    this.maxBufferSize = options.maxBufferSize ?? DEFAULT_MAX_BUFFER_SIZE;
+    this.warningThreshold = options.warningThreshold ?? DEFAULT_WARNING_THRESHOLD;
+    this.now = options.now ?? Date.now;
+
+    if (this.persistence) {
+      const restored = this.persistence.load();
+      this.buffer.push(...restored);
+      this.enforceBufferLimit();
+    }
+  }
+
+  setAuditLevel(level: AuditLevel): void {
+    this.auditLevel = level;
+  }
+
+  get bufferSize(): number {
+    return this.buffer.length;
+  }
+
+  get bufferCapacity(): number {
+    return this.maxBufferSize;
+  }
+
+  /**
+   * Enqueue an event. No-op when `auditLevel === "off"`.
+   * Returns the resulting buffer length (useful for tests).
+   */
+  enqueue(draft: AuditEventDraft): number {
+    if (this.auditLevel === "off") return this.buffer.length;
+
+    const event: AuditEvent = {
+      userId: this.identity.userId,
+      orgId: this.identity.orgId,
+      agentId: draft.agentId,
+      sessionKey: draft.sessionKey,
+      eventType: draft.eventType,
+      toolName: draft.toolName,
+      timestamp: this.now(),
+      outcome: draft.outcome,
+      metadata: this.auditLevel === "full" ? draft.metadata : undefined,
+    };
+
+    this.buffer.push(event);
+
+    if (this.buffer.length > this.maxBufferSize) {
+      const dropped = this.buffer.length - this.maxBufferSize;
+      this.buffer.splice(0, dropped);
+      this.logger?.warn(`Audit buffer exceeded max size (${this.maxBufferSize}). Dropped ${dropped} oldest event(s).`);
+    }
+
+    const ratio = this.buffer.length / this.maxBufferSize;
+    if (ratio > this.warningThreshold && !this.hasWarnedCapacity) {
+      this.hasWarnedCapacity = true;
+      this.logger?.warn(
+        `Audit buffer approaching capacity: ${this.buffer.length}/${this.maxBufferSize} (${Math.round(ratio * 100)}%)`,
+      );
+    } else if (ratio <= this.warningThreshold) {
+      this.hasWarnedCapacity = false;
+    }
+
+    return this.buffer.length;
+  }
+
+  /**
+   * True when enqueueing has accumulated enough events that the caller's
+   * timer should trigger a flush early. Callers may also call flush
+   * directly at any time.
+   */
+  shouldFlush(): boolean {
+    return this.buffer.length >= this.batchSize;
+  }
+
+  /**
+   * Drain the queue and hand the batch to the transport. On failure,
+   * the batch goes back on the head of the buffer and is checkpointed
+   * via persistence. On success, persistence is cleared.
+   */
+  async flush(): Promise<void> {
+    if (this.buffer.length === 0) return;
+
+    const batch = this.buffer.splice(0);
+    let delivered = false;
+    try {
+      delivered = await this.transport(batch);
+    } catch (err) {
+      this.logger?.warn(`Audit transport threw: ${String(err)}`);
+      delivered = false;
+    }
+
+    if (delivered) {
+      this.hasWarnedCapacity = false;
+      this.persistence?.clear();
+    } else {
+      this.buffer.unshift(...batch);
+      this.enforceBufferLimit();
+      this.persistence?.save(this.buffer);
+    }
+  }
+
+  /** Drop all buffered events without delivering. Used in tests + shutdown paths. */
+  reset(): void {
+    this.buffer = [];
+    this.hasWarnedCapacity = false;
+    this.persistence?.clear();
+  }
+
+  private enforceBufferLimit(): void {
+    if (this.buffer.length > this.maxBufferSize) {
+      const dropped = this.buffer.length - this.maxBufferSize;
+      this.buffer.splice(0, dropped);
+      this.logger?.warn(
+        `Audit buffer trimmed: dropped ${dropped} oldest event(s) to stay within limit (${this.maxBufferSize}).`,
+      );
+    }
+  }
+}

--- a/packages/audit-events/src/serialize.test.ts
+++ b/packages/audit-events/src/serialize.test.ts
@@ -1,0 +1,51 @@
+import type { AuditEvent } from "@clawforgeai/contracts";
+import { describe, expect, it } from "vitest";
+import { parseJsonl, serializeJsonl } from "./serialize.js";
+
+const sample: AuditEvent[] = [
+  {
+    userId: "u1",
+    orgId: "o1",
+    eventType: "tool_call_attempt",
+    outcome: "allowed",
+    timestamp: 1,
+  },
+  {
+    userId: "u1",
+    orgId: "o1",
+    eventType: "tool_call_attempt",
+    outcome: "blocked",
+    toolName: "exec",
+    timestamp: 2,
+    metadata: { reason: "deny_list" },
+  },
+];
+
+describe("serializeJsonl / parseJsonl", () => {
+  it("round-trips a batch of events", () => {
+    const out = serializeJsonl(sample);
+    expect(out.endsWith("\n")).toBe(true);
+    expect(out.split("\n").filter(Boolean)).toHaveLength(2);
+
+    const parsed = parseJsonl(out);
+    expect(parsed).toEqual(sample);
+  });
+
+  it("returns empty string for an empty batch", () => {
+    expect(serializeJsonl([])).toBe("");
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(parseJsonl("")).toEqual([]);
+  });
+
+  it("skips malformed lines", () => {
+    const raw = [
+      '{"userId":"u1","orgId":"o1","eventType":"tool_call_attempt","outcome":"allowed","timestamp":1}',
+      "not-json",
+      "",
+    ].join("\n");
+    const parsed = parseJsonl(raw);
+    expect(parsed).toHaveLength(1);
+  });
+});

--- a/packages/audit-events/src/serialize.ts
+++ b/packages/audit-events/src/serialize.ts
@@ -1,0 +1,26 @@
+import type { AuditEvent } from "@clawforgeai/contracts";
+
+/** Serialize a batch of audit events to newline-delimited JSON (one event per line). */
+export function serializeJsonl(events: AuditEvent[]): string {
+  if (events.length === 0) return "";
+  return events.map((event) => JSON.stringify(event)).join("\n") + "\n";
+}
+
+/**
+ * Parse newline-delimited JSON back into events. Malformed lines are skipped
+ * (best-effort recovery path used by persistence reloads after a crash).
+ */
+export function parseJsonl(raw: string): AuditEvent[] {
+  if (!raw) return [];
+  const events: AuditEvent[] = [];
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      events.push(JSON.parse(trimmed) as AuditEvent);
+    } catch {
+      // Skip malformed lines — recovery is best-effort.
+    }
+  }
+  return events;
+}

--- a/packages/audit-events/src/types.ts
+++ b/packages/audit-events/src/types.ts
@@ -1,0 +1,78 @@
+import type { AuditEvent, AuditEventType } from "@clawforgeai/contracts";
+
+export type { AuditEvent, AuditEventType };
+
+export type AuditOutcome = AuditEvent["outcome"];
+
+/**
+ * Audit-record level inherited from the org policy. Controls how much
+ * payload detail is retained on each event.
+ *
+ * - "full"     — include `metadata` on every event
+ * - "metadata" — drop the `metadata` payload but keep counters and reasons
+ * - "off"      — drop events entirely
+ */
+export type AuditLevel = "full" | "metadata" | "off";
+
+/** Minimal logger surface used by the batched queue for warnings. */
+export interface AuditLoggerSink {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+}
+
+/**
+ * Inputs accepted by `BatchedAuditQueue.enqueue`. Identity fields
+ * (userId, orgId, timestamp) are filled in by the queue from the
+ * caller-supplied identity context, keeping enqueue sites terse.
+ */
+export interface AuditEventDraft {
+  eventType: AuditEventType;
+  outcome: AuditOutcome;
+  toolName?: string;
+  agentId?: string;
+  sessionKey?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/** Identity context attached to every event the queue emits. */
+export interface AuditIdentity {
+  userId: string;
+  orgId: string;
+}
+
+/**
+ * Transport hook called by the queue when a batch is ready. Returns
+ * `true` on successful delivery; `false` puts the batch back on the
+ * head of the buffer (for retry on the next flush) and signals the
+ * persistence layer to checkpoint.
+ */
+export type AuditTransport = (batch: AuditEvent[]) => Promise<boolean>;
+
+/**
+ * Optional durable persistence hook. The queue calls `save` after a
+ * failed flush so the caller (plugin or worker) can checkpoint to disk
+ * for crash resilience, and `load` once at startup to recover unshipped
+ * events. Implementations should be best-effort and never throw.
+ */
+export interface AuditPersistence {
+  load: () => AuditEvent[];
+  save: (events: AuditEvent[]) => void;
+  clear: () => void;
+}
+
+export interface BatchedAuditQueueOptions {
+  identity: AuditIdentity;
+  transport: AuditTransport;
+  persistence?: AuditPersistence;
+  logger?: AuditLoggerSink;
+  auditLevel?: AuditLevel;
+  /** Number of events that triggers an automatic flush. Default 100. */
+  batchSize?: number;
+  /** Maximum events held in memory. Oldest are dropped beyond this. Default 10_000. */
+  maxBufferSize?: number;
+  /** Capacity ratio (0..1) at which a single warning is emitted. Default 0.8. */
+  warningThreshold?: number;
+  /** Clock for testability — defaults to `Date.now`. */
+  now?: () => number;
+}


### PR DESCRIPTION
## What changed

Implements \`@clawforgeai/audit-events\` with the pure pieces needed by the plugin and any future audit-emitting runtime:

- **\`BatchedAuditQueue\`** — bounded in-memory queue, drop-oldest overflow, auto-flush on batchSize, capacity warning at threshold. Transport and persistence are injected so the package is pure of network/FS.
- **\`AuditTransport\` / \`AuditPersistence\`** interfaces.
- **\`serializeJsonl\` / \`parseJsonl\`** helpers for the persisted buffer format the plugin already writes to \`~/.openclaw/clawforge/audit-buffer.jsonl\`.
- Re-exports \`AuditEvent\` / \`AuditEventType\` from \`@clawforgeai/contracts\`.

## Why

Phase 1 (\`docs/technical-strategy.md\`) extracts shared platform primitives. The audit logger inside \`plugin/src/audit/audit-logger.ts\` mixes pure queueing logic with HTTP transport and disk persistence — splitting them lets the same queue power future runtime adapters and server-side workers.

## How to test

- [x] \`pnpm --filter @clawforgeai/audit-events test\` — **19 tests pass**
- [x] \`pnpm --filter @clawforgeai/audit-events build\` — clean
- [x] \`pnpm --filter @clawforgeai/audit-events typecheck\` — clean
- [x] \`pnpm format:check\` — clean
- [x] \`pnpm lint\` — 0 errors

## Parity contract

Mirrors \`plugin/src/audit/audit-logger.ts\` byte-for-byte:
- \`auditLevel === "off"\` → no-op enqueue
- \`auditLevel === "metadata"\` → drop \`metadata\` payload, keep counters
- auto-flush once \`buffer.length >= batchSize\`
- exceed \`maxBufferSize\` → evict oldest with a warning
- single capacity warning per cycle above threshold
- failed transport → requeue + persistence.save
- thrown transport → same as failed, with warning
- successful transport → persistence.clear + reset capacity warning
- reload from persistence at construction, trim to maxBufferSize

## Checklist

- [x] No changes to plugin/server/admin (extraction only)
- [x] No I/O in the package — transport and persistence injected
- [x] Imports stay one-way: \`audit-events\` → \`contracts\`