### PR TITLE
feat(agent-sdk): runtime contract + BaseRuntimeAdapter (Phase 1 #164)

### DIFF
--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -24,7 +24,8 @@
   },
   "dependencies": {
     "@clawforgeai/audit-events": "workspace:*",
-    "@clawforgeai/contracts": "workspace:*"
+    "@clawforgeai/contracts": "workspace:*",
+    "@clawforgeai/policy-engine": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/packages/agent-sdk/src/base-adapter.test.ts
+++ b/packages/agent-sdk/src/base-adapter.test.ts
@@ -1,0 +1,109 @@
+import type { OrgPolicy } from "@clawforgeai/contracts";
+import { describe, expect, it, vi } from "vitest";
+import { BaseRuntimeAdapter } from "./base-adapter.js";
+import type { BaseAdapterOptions } from "./base-adapter.js";
+
+class TestAdapter extends BaseRuntimeAdapter {
+  // Expose protected hooks for verification in tests.
+  getPolicy() {
+    return this.policy;
+  }
+  isPendingInit() {
+    return this.pendingInit;
+  }
+}
+
+function makePolicy(overrides?: Partial<OrgPolicy>): OrgPolicy {
+  return {
+    version: 1,
+    tools: {},
+    skills: { approved: [], requireApproval: false },
+    killSwitch: { active: false },
+    auditLevel: "metadata",
+    ...overrides,
+  };
+}
+
+function makeAdapter(overrides?: Partial<BaseAdapterOptions>): {
+  adapter: TestAdapter;
+  transport: ReturnType<typeof vi.fn>;
+} {
+  const transport = vi.fn(async () => true);
+  const adapter = new TestAdapter({
+    identity: { userId: "u1", orgId: "o1" },
+    auditTransport: transport,
+    auditLevel: "full",
+    ...overrides,
+  });
+  return { adapter, transport };
+}
+
+describe("BaseRuntimeAdapter", () => {
+  describe("state management", () => {
+    it("starts in pending-init with no policy", () => {
+      const { adapter } = makeAdapter();
+      expect(adapter.getPolicy()).toBeNull();
+      expect(adapter.isPendingInit()).toBe(true);
+    });
+
+    it("setPolicy clears pending-init and stores the policy", () => {
+      const { adapter } = makeAdapter();
+      const policy = makePolicy();
+      adapter.setPolicy(policy);
+      expect(adapter.getPolicy()).toBe(policy);
+      expect(adapter.isPendingInit()).toBe(false);
+    });
+
+    it("markInitialized clears pending-init without setting a policy", () => {
+      const { adapter } = makeAdapter();
+      adapter.markInitialized();
+      expect(adapter.isPendingInit()).toBe(false);
+      expect(adapter.getPolicy()).toBeNull();
+    });
+  });
+
+  describe("evaluateTool", () => {
+    it("blocks during pending-init when no policy is loaded", () => {
+      const { adapter } = makeAdapter();
+      const decision = adapter.evaluateTool({ rawToolName: "read", params: {} });
+      expect(decision.outcome).toBe("deny");
+      expect(decision.reason).toBe("pending_init");
+    });
+
+    it("applies kill switch state set via setKillSwitch", () => {
+      const { adapter } = makeAdapter();
+      adapter.markInitialized();
+      adapter.setKillSwitch(true, "shutdown");
+      const decision = adapter.evaluateTool({ rawToolName: "read", params: {} });
+      expect(decision).toMatchObject({ outcome: "deny", reason: "kill_switch", blockMessage: "shutdown" });
+    });
+
+    it("applies the latest policy after setPolicy", () => {
+      const { adapter } = makeAdapter();
+      adapter.setPolicy(makePolicy({ tools: { deny: ["exec"] } }));
+      const decision = adapter.evaluateTool({ rawToolName: "exec", params: {} });
+      expect(decision.outcome).toBe("deny");
+      expect(decision.reason).toBe("deny_list");
+    });
+
+    it("applies offline override set via setOfflineOverride", () => {
+      const { adapter } = makeAdapter();
+      adapter.setPolicy(makePolicy({ tools: { deny: ["exec"] } }));
+      adapter.setOfflineOverride("allow");
+      const decision = adapter.evaluateTool({ rawToolName: "exec", params: {} });
+      expect(decision.outcome).toBe("allow");
+      expect(decision.reason).toBe("offline_allow_mode");
+    });
+  });
+
+  describe("audit", () => {
+    it("emitEvent buffers events that flush ships to the transport", async () => {
+      const { adapter, transport } = makeAdapter();
+      adapter.emitEvent({ eventType: "tool_call_attempt", outcome: "allowed", toolName: "read" });
+      adapter.emitEvent({ eventType: "tool_call_attempt", outcome: "blocked", toolName: "exec" });
+      await adapter.flushAudit();
+      expect(transport).toHaveBeenCalledTimes(1);
+      expect(transport.mock.calls[0]?.[0]).toHaveLength(2);
+    });
+  });
+});

--- a/packages/agent-sdk/src/base-adapter.ts
+++ b/packages/agent-sdk/src/base-adapter.ts
@@ -1,0 +1,91 @@
+import { BatchedAuditQueue } from "@clawforgeai/audit-events";
+import type { AuditTransport, AuditPersistence, AuditEventDraft, AuditLevel } from "@clawforgeai/audit-events";
+import type { OrgPolicy } from "@clawforgeai/contracts";
+import type { PolicyDecision, PolicyEvaluationContext, ToolCallEvaluationInput } from "@clawforgeai/policy-engine";
+import { evaluateToolCall } from "@clawforgeai/policy-engine";
+
+export interface BaseAdapterOptions {
+  identity: { userId: string; orgId: string };
+  auditTransport: AuditTransport;
+  auditPersistence?: AuditPersistence;
+  auditLevel?: AuditLevel;
+  logger?: { info: (msg: string) => void; warn: (msg: string) => void; error: (msg: string) => void };
+}
+
+/**
+ * Convenience scaffold for runtime adapters. Bundles:
+ *   - a `BatchedAuditQueue` for the adapter to enqueue events into
+ *   - a `policy-engine` accessor that always evaluates against the
+ *     last applied policy + the adapter's current kill-switch + offline state
+ *
+ * Runtime-specific methods (`registerAgent`, `startRun`, etc.) are left
+ * to subclasses, which decide how their host runtime exposes those hooks.
+ *
+ * Adapter authors who prefer raw composition can ignore this class and
+ * wire `BatchedAuditQueue` + `evaluateToolCall` themselves.
+ */
+export abstract class BaseRuntimeAdapter {
+  protected readonly auditQueue: BatchedAuditQueue;
+  protected policy: OrgPolicy | null = null;
+  protected killSwitchActive = false;
+  protected killSwitchMessage: string | undefined;
+  protected offlineOverride: "allow" | "cached" | undefined;
+  protected pendingInit = true;
+
+  constructor(protected readonly options: BaseAdapterOptions) {
+    this.auditQueue = new BatchedAuditQueue({
+      identity: options.identity,
+      transport: options.auditTransport,
+      persistence: options.auditPersistence,
+      logger: options.logger,
+      auditLevel: options.auditLevel ?? "metadata",
+    });
+  }
+
+  /** Apply the latest org policy. Future tool calls evaluate against this. */
+  setPolicy(policy: OrgPolicy | null): void {
+    this.policy = policy;
+    this.pendingInit = false;
+  }
+
+  /** Toggle the org kill switch state observed by future evaluations. */
+  setKillSwitch(active: boolean, message?: string): void {
+    this.killSwitchActive = active;
+    this.killSwitchMessage = message;
+  }
+
+  /** Set or clear the offline override (controls cached vs. allow-all behavior). */
+  setOfflineOverride(mode: "allow" | "cached" | undefined): void {
+    this.offlineOverride = mode;
+  }
+
+  /** Mark initialization complete (clears pending-init safe mode). */
+  markInitialized(): void {
+    this.pendingInit = false;
+  }
+
+  /** Enqueue an audit event; the queue auto-flushes when batchSize is hit. */
+  emitEvent(draft: AuditEventDraft): void {
+    this.auditQueue.enqueue(draft);
+  }
+
+  /** Force-flush the audit queue (typically called on shutdown). */
+  async flushAudit(): Promise<void> {
+    await this.auditQueue.flush();
+  }
+
+  /**
+   * Evaluate a tool call against the current state. Pure passthrough to
+   * the policy-engine — adapters call this from their pre-tool hook.
+   */
+  evaluateTool(input: ToolCallEvaluationInput): PolicyDecision {
+    const ctx: PolicyEvaluationContext = {
+      policy: this.policy,
+      killSwitchActive: this.killSwitchActive,
+      killSwitchMessage: this.killSwitchMessage,
+      offlineOverride: this.offlineOverride,
+      pendingInit: this.pendingInit,
+    };
+    return evaluateToolCall(ctx, input);
+  }
+}

--- a/packages/agent-sdk/src/index.test.ts
+++ b/packages/agent-sdk/src/index.test.ts
@@ -1,8 +1,0 @@
-import { describe, expect, it } from "vitest";
-import { PACKAGE_NAME } from "./index.js";
-
-describe("@clawforgeai/agent-sdk", () => {
-  it("exports PACKAGE_NAME", () => {
-    expect(PACKAGE_NAME).toBe("@clawforgeai/agent-sdk");
-  });
-});

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -1,1 +1,5 @@
 export const PACKAGE_NAME = "@clawforgeai/agent-sdk";
+
+export * from "./runtime-adapter.js";
+export { BaseRuntimeAdapter } from "./base-adapter.js";
+export type { BaseAdapterOptions } from "./base-adapter.js";

--- a/packages/agent-sdk/src/runtime-adapter.test.ts
+++ b/packages/agent-sdk/src/runtime-adapter.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { RuntimeCapabilityError } from "./runtime-adapter.js";
+
+describe("RuntimeCapabilityError", () => {
+  it("includes the capability name in the message", () => {
+    const err = new RuntimeCapabilityError("pre_tool_hook");
+    expect(err.message).toContain("pre_tool_hook");
+    expect(err.name).toBe("RuntimeCapabilityError");
+  });
+
+  it("includes the runtime kind in the message when provided", () => {
+    const err = new RuntimeCapabilityError("artifacts", "claude-code");
+    expect(err.message).toContain("claude-code");
+    expect(err.message).toContain("artifacts");
+  });
+});

--- a/packages/agent-sdk/src/runtime-adapter.ts
+++ b/packages/agent-sdk/src/runtime-adapter.ts
@@ -1,0 +1,136 @@
+import type {
+  Action,
+  ApprovalDecision,
+  ApprovalRequest,
+  AuditEvent,
+  AuditEventType,
+  OrgPolicy,
+  Run,
+  RuntimeRegistration,
+} from "@clawforgeai/contracts";
+import type { PolicyDecision } from "@clawforgeai/policy-engine";
+
+/**
+ * Minimal tool descriptor reported by an adapter. Adapters supply only the
+ * fields they have — the platform tolerates partial descriptors and enriches
+ * them server-side from the tool-governance package.
+ */
+export interface ToolDescriptor {
+  name: string;
+  description?: string;
+  /** Optional capability metadata (e.g. "filesystem", "network"). */
+  tags?: string[];
+}
+
+/**
+ * Aggregated usage report submitted at the end of a run (or periodically
+ * for long-running runs). All fields are optional — adapters supply what
+ * their runtime tracks.
+ */
+export interface UsageReport {
+  promptTokens?: number;
+  completionTokens?: number;
+  toolCalls?: number;
+  durationMs?: number;
+  failures?: number;
+}
+
+/** Reference to an output collected by the adapter at the end of a run. */
+export interface ArtifactRef {
+  id: string;
+  kind: "log" | "file" | "url" | "diff";
+  uri?: string;
+  bytes?: number;
+  contentType?: string;
+}
+
+export interface StartRunInput {
+  agentInstanceId: string;
+  userId: string;
+  orgId: string;
+  parentRunId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * The canonical surface every ClawForge runtime adapter implements.
+ *
+ * Phase 1 introduces the contract; not every runtime supports every method
+ * yet. Adapters can throw `RuntimeCapabilityError` for unsupported
+ * operations rather than silently no-op'ing them.
+ *
+ * Methods grouped by lifecycle phase:
+ *   register      -> identity + capability advertisement
+ *   start/pause/resume/cancel -> run lifecycle
+ *   requestApproval / emitEvent -> in-run governance
+ *   applyPolicy / reportUsage / collectArtifacts -> control & wrap-up
+ */
+export interface RuntimeAdapter {
+  /** Advertise the runtime kind, version, and capabilities to the control plane. */
+  registerAgent(registration: RuntimeRegistration): Promise<RuntimeRegistrationResult>;
+
+  /** Begin a new run. Returns the canonical Run record. */
+  startRun(input: StartRunInput): Promise<Run>;
+
+  /** Pause a running run; no new actions accepted until resumed. */
+  pauseRun(runId: string): Promise<void>;
+
+  /** Resume a paused run. */
+  resumeRun(runId: string): Promise<void>;
+
+  /** Cancel a run; the adapter MUST stop tool execution. */
+  cancelRun(runId: string, reason?: string): Promise<void>;
+
+  /**
+   * Ask the control plane to gate an action. The adapter MUST block its
+   * runtime on the returned promise — resolution carries the human decision.
+   */
+  requestApproval(action: Action, request: ApprovalRequest): Promise<ApprovalDecision>;
+
+  /**
+   * Emit a single audit event. Adapters typically queue + batch via
+   * `BatchedAuditQueue` from `@clawforgeai/audit-events`.
+   */
+  emitEvent(event: Omit<AuditEvent, "userId" | "orgId" | "timestamp">): void;
+
+  /** Report the tools the runtime currently exposes. */
+  listTools(): Promise<ToolDescriptor[]>;
+
+  /**
+   * Receive a new effective policy from the control plane. The adapter
+   * should apply it before the next action evaluation. The returned decision
+   * (if provided) hints whether subsequent action evaluation should pause —
+   * typically used in tests.
+   */
+  applyPolicy(policy: OrgPolicy): Promise<PolicyDecision | void>;
+
+  /** Report aggregated usage for a run. May be called multiple times. */
+  reportUsage(runId: string, usage: UsageReport): Promise<void>;
+
+  /** Return references to artifacts produced during the run. */
+  collectArtifacts(runId: string): Promise<ArtifactRef[]>;
+}
+
+export interface RuntimeRegistrationResult {
+  agentInstanceId: string;
+  /** Wall-clock the control plane assigned to this registration. */
+  enrolledAt: string;
+}
+
+/** Thrown when an adapter is asked for a capability it does not advertise. */
+export class RuntimeCapabilityError extends Error {
+  constructor(
+    public readonly capability: string,
+    public readonly runtimeKind?: string,
+  ) {
+    super(
+      runtimeKind
+        ? `Runtime "${runtimeKind}" does not support capability "${capability}"`
+        : `Runtime does not support capability "${capability}"`,
+    );
+    this.name = "RuntimeCapabilityError";
+  }
+}
+
+/** Re-export for adapter authors who route their own audit emission. */
+export type { AuditEvent, AuditEventType };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       '@clawforgeai/contracts':
         specifier: workspace:*
         version: link:../contracts
+      '@clawforgeai/policy-engine':
+        specifier: workspace:*
+        version: link:../policy-engine
     devDependencies:
       '@types/node':
         specifier: ^25.6.0
@@ -2160,6 +2163,9 @@ packages:
   '@protobufjs/codegen@2.0.4':
     resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
 
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
   '@protobufjs/eventemitter@1.1.0':
     resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
 
@@ -2172,6 +2178,9 @@ packages:
   '@protobufjs/inquire@1.1.0':
     resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
 
+  '@protobufjs/inquire@1.1.1':
+    resolution: {integrity: sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==}
+
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
 
@@ -2180,6 +2189,9 @@ packages:
 
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@reflink/reflink-darwin-arm64@0.1.19':
     resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
@@ -2680,17 +2692,11 @@ packages:
   '@types/jsonwebtoken@9.0.10':
     resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
 
-  '@types/long@4.0.2':
-    resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
-
   '@types/mime-types@2.1.4':
     resolution: {integrity: sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
-
-  '@types/node@10.17.60':
-    resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -2858,10 +2864,6 @@ packages:
         optional: true
       link-preview-js:
         optional: true
-
-  '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
-    resolution: {tarball: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67}
-    version: 2.0.1
 
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -4335,6 +4337,10 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  libsignal@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7:
+    resolution: {tarball: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7}
+    version: 6.0.0
+
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
@@ -4421,9 +4427,6 @@ packages:
   log-symbols@7.0.1:
     resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
     engines: {node: '>=18'}
-
-  long@4.0.0:
-    resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -5107,12 +5110,12 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
-  protobufjs@6.8.8:
-    resolution: {integrity: sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==}
-    hasBin: true
-
   protobufjs@7.5.4:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
+
+  protobufjs@7.5.8:
+    resolution: {integrity: sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -8023,6 +8026,8 @@ snapshots:
 
   '@protobufjs/codegen@2.0.4': {}
 
+  '@protobufjs/codegen@2.0.5': {}
+
   '@protobufjs/eventemitter@1.1.0': {}
 
   '@protobufjs/fetch@1.1.0':
@@ -8034,11 +8039,15 @@ snapshots:
 
   '@protobufjs/inquire@1.1.0': {}
 
+  '@protobufjs/inquire@1.1.1': {}
+
   '@protobufjs/path@1.1.2': {}
 
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@reflink/reflink-darwin-arm64@0.1.19':
     optional: true
@@ -8634,13 +8643,9 @@ snapshots:
       '@types/ms': 2.1.0
       '@types/node': 25.6.0
 
-  '@types/long@4.0.2': {}
-
   '@types/mime-types@2.1.4': {}
 
   '@types/ms@2.1.0': {}
-
-  '@types/node@10.17.60': {}
 
   '@types/node@12.20.55': {}
 
@@ -8851,7 +8856,7 @@ snapshots:
       '@cacheable/node-cache': 1.7.6
       '@hapi/boom': 9.1.4
       async-mutex: 0.5.0
-      libsignal: '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67'
+      libsignal: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7
       lru-cache: 11.2.6
       music-metadata: 11.12.1
       p-queue: 9.1.0
@@ -8863,11 +8868,6 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
-
-  '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
-    dependencies:
-      curve25519-js: 0.0.4
-      protobufjs: 6.8.8
 
   abbrev@1.1.1:
     optional: true
@@ -10451,6 +10451,11 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  libsignal@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/bcea72df9ec34d9d9140ab30619cf479c7c144c7:
+    dependencies:
+      curve25519-js: 0.0.4
+      protobufjs: 7.5.8
+
   lie@3.3.0:
     dependencies:
       immediate: 3.0.6
@@ -10524,8 +10529,6 @@ snapshots:
     dependencies:
       is-unicode-supported: 2.1.0
       yoctocolors: 2.1.2
-
-  long@4.0.0: {}
 
   long@5.3.2: {}
 
@@ -11295,22 +11298,6 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
-  protobufjs@6.8.8:
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
-      '@types/long': 4.0.2
-      '@types/node': 10.17.60
-      long: 4.0.0
-
   protobufjs@7.5.4:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -11323,6 +11310,21 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
+      '@types/node': 25.6.0
+      long: 5.3.2
+
+  protobufjs@7.5.8:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.1
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
       '@types/node': 25.6.0
       long: 5.3.2
 


### PR DESCRIPTION
## What changed

Defines \`@clawforgeai/agent-sdk\` — the canonical surface every ClawForge runtime adapter implements:

- **\`RuntimeAdapter\` interface** — \`registerAgent\` / \`startRun\` / \`pauseRun\` / \`resumeRun\` / \`cancelRun\` / \`requestApproval\` / \`emitEvent\` / \`listTools\` / \`applyPolicy\` / \`reportUsage\` / \`collectArtifacts\`.
- **Supporting types** — \`ToolDescriptor\`, \`UsageReport\`, \`ArtifactRef\`, \`StartRunInput\`, \`RuntimeRegistrationResult\`, \`RuntimeCapabilityError\`.
- **\`BaseRuntimeAdapter\`** — thin scaffold that bundles \`@clawforgeai/audit-events\` + \`@clawforgeai/policy-engine\` for adapters that want one. Lifecycle methods stay abstract.

## Why

Phase 1 (\`docs/technical-strategy.md\`) closes the platform foundation with a contract that all future runtimes implement, so subsequent adapters (Claude Code in Phase 2 — #148, etc.) don't recreate identity / audit / policy plumbing.

The OpenClaw plugin existed before this contract, so the plugin refactor PR (#147) composes \`audit-events\` + \`policy-engine\` directly rather than subclassing \`BaseRuntimeAdapter\` — both styles are first-class.

## How to test

- [x] \`pnpm --filter @clawforgeai/agent-sdk test\` — **10 tests pass** (state transitions, policy + kill-switch + offline override threading, audit queue passthrough)
- [x] \`pnpm --filter @clawforgeai/agent-sdk build\` — clean
- [x] \`pnpm --filter @clawforgeai/agent-sdk typecheck\` — clean
- [x] \`pnpm format:check\` / \`pnpm lint\` / \`pnpm check:deps\` — clean

## Checklist

- [x] No changes to plugin/server/admin (interfaces only)
- [x] Imports stay one-way: \`agent-sdk\` → \`audit-events\` + \`policy-engine\` + \`contracts\`
- [x] Adapters can ignore \`BaseRuntimeAdapter\` and compose primitives directly