### PR TITLE
feat(plugin): consume policy-engine + audit-events (Phase 1 #146/#147)

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -51,6 +51,9 @@
     "openclaw": "*"
   },
   "dependencies": {
+    "@clawforgeai/audit-events": "workspace:*",
+    "@clawforgeai/contracts": "workspace:*",
+    "@clawforgeai/policy-engine": "workspace:*",
     "@clawforgeai/tool-governance": "workspace:*"
   },
   "devDependencies": {

--- a/plugin/src/audit/audit-logger.ts
+++ b/plugin/src/audit/audit-logger.ts
@@ -1,13 +1,21 @@
 /**
  * Audit logger for ClawForge.
- * Buffers audit events and ships them to the control plane in batches.
- * Persists unshipped events to disk for crash resilience.
- * Enforces a configurable maximum buffer size, dropping oldest events when exceeded.
+ *
+ * Thin plugin-specific wrapper around `BatchedAuditQueue` from
+ * `@clawforgeai/audit-events`. The queue owns the bounded buffer,
+ * drop-oldest overflow, capacity warnings, and batch-size auto-flush.
+ * This wrapper supplies:
+ *   - HTTP transport to `POST /api/v1/audit/:orgId/events`
+ *   - Filesystem persistence at `~/.openclaw/clawforge/audit-buffer.jsonl`
+ *   - A periodic flush timer
+ *   - Token mutation hooks for session refresh
  */
 
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { BatchedAuditQueue, parseJsonl, serializeJsonl } from "@clawforgeai/audit-events";
+import type { AuditEvent as PackageAuditEvent, AuditPersistence, AuditTransport } from "@clawforgeai/audit-events";
 import type { AuditEvent, AuditEventType, ClawForgePluginConfig, SessionTokens } from "../types.js";
 
 const CLAWFORGE_DIR = path.join(os.homedir(), ".openclaw", "clawforge");
@@ -16,7 +24,6 @@ const BUFFER_FILE = path.join(CLAWFORGE_DIR, "audit-buffer.jsonl");
 const DEFAULT_BATCH_SIZE = 100;
 const DEFAULT_FLUSH_INTERVAL_MS = 30_000;
 const DEFAULT_MAX_BUFFER_SIZE = 10_000;
-const BUFFER_WARNING_THRESHOLD = 0.8; // Warn at 80% capacity
 
 export type AuditLoggerEnqueueParams = {
   eventType: AuditEventType;
@@ -27,241 +34,151 @@ export type AuditLoggerEnqueueParams = {
   metadata?: Record<string, unknown>;
 };
 
+type LoggerSink = { info: (msg: string) => void; warn: (msg: string) => void; error: (msg: string) => void };
+
 export class AuditLogger {
-  private buffer: AuditEvent[] = [];
-  private flushTimer: ReturnType<typeof setInterval> | null = null;
-  private readonly batchSize: number;
+  private readonly queue: BatchedAuditQueue;
   private readonly flushIntervalMs: number;
-  private readonly maxBufferSize: number;
+  private flushTimer: ReturnType<typeof setInterval> | null = null;
   private controlPlaneUrl: string;
   private orgId: string;
-  private userId: string;
   private accessToken: string;
-  private auditLevel: "full" | "metadata" | "off";
-  private logger?: { info: (msg: string) => void; warn: (msg: string) => void; error: (msg: string) => void };
-  private hasWarnedCapacity = false;
+  private logger?: LoggerSink;
 
   constructor(params: {
     config: ClawForgePluginConfig;
     session: SessionTokens;
     auditLevel?: "full" | "metadata" | "off";
-    logger?: { info: (msg: string) => void; warn: (msg: string) => void; error: (msg: string) => void };
+    logger?: LoggerSink;
   }) {
     this.controlPlaneUrl = params.config.controlPlaneUrl ?? "";
     this.orgId = params.session.orgId;
-    this.userId = params.session.userId;
     this.accessToken = params.session.accessToken;
-    this.batchSize = params.config.auditBatchSize ?? DEFAULT_BATCH_SIZE;
     this.flushIntervalMs = params.config.auditFlushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS;
-    this.maxBufferSize = params.config.maxAuditBufferSize ?? DEFAULT_MAX_BUFFER_SIZE;
-    this.auditLevel = params.auditLevel ?? "metadata";
     this.logger = params.logger;
 
-    // Load any unshipped events from disk.
-    this.loadPersistedBuffer();
+    const transport: AuditTransport = async (batch) => {
+      if (!this.controlPlaneUrl) {
+        // No control plane configured -> treat as failed delivery so the
+        // queue requeues and persistence checkpoints.
+        return false;
+      }
+      try {
+        const url = `${this.controlPlaneUrl}/api/v1/audit/${encodeURIComponent(this.orgId)}/events`;
+        const response = await fetch(url, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${this.accessToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ events: batch }),
+        });
+        if (!response.ok) {
+          this.logger?.warn(`Audit event submission failed (${response.status})`);
+          return false;
+        }
+        this.logger?.info(`Shipped ${batch.length} audit events`);
+        return true;
+      } catch (err) {
+        this.logger?.warn(`Audit event submission error: ${String(err)}`);
+        return false;
+      }
+    };
+
+    const persistence: AuditPersistence = {
+      load: () => {
+        try {
+          const raw = fs.readFileSync(BUFFER_FILE, "utf-8");
+          return parseJsonl(raw) as PackageAuditEvent[];
+        } catch {
+          return [];
+        }
+      },
+      save: (events) => {
+        try {
+          fs.mkdirSync(CLAWFORGE_DIR, { recursive: true });
+          fs.writeFileSync(BUFFER_FILE, serializeJsonl(events), { mode: 0o600 });
+        } catch {
+          // Best-effort.
+        }
+      },
+      clear: () => {
+        try {
+          fs.unlinkSync(BUFFER_FILE);
+        } catch {
+          // Ignore.
+        }
+      },
+    };
+
+    this.queue = new BatchedAuditQueue({
+      identity: { userId: params.session.userId, orgId: params.session.orgId },
+      transport,
+      persistence,
+      logger: this.logger,
+      auditLevel: params.auditLevel ?? "metadata",
+      batchSize: params.config.auditBatchSize ?? DEFAULT_BATCH_SIZE,
+      maxBufferSize: params.config.maxAuditBufferSize ?? DEFAULT_MAX_BUFFER_SIZE,
+    });
   }
 
-  /**
-   * Start the periodic flush timer.
-   */
+  /** Start the periodic flush timer. */
   start(): void {
-    if (this.flushTimer) {
-      return;
-    }
+    if (this.flushTimer) return;
     this.flushTimer = setInterval(() => {
-      this.flush().catch((err) => {
-        this.logger?.warn(`Audit flush failed: ${String(err)}`);
-      });
+      this.queue.flush().catch((err) => this.logger?.warn(`Audit flush failed: ${String(err)}`));
     }, this.flushIntervalMs);
-    // Allow the process to exit even if the timer is still running.
-    if (this.flushTimer.unref) {
-      this.flushTimer.unref();
-    }
+    if (this.flushTimer.unref) this.flushTimer.unref();
   }
 
-  /**
-   * Stop the periodic flush timer and flush remaining events.
-   */
+  /** Stop the periodic flush timer and flush remaining events. */
   async stop(): Promise<void> {
     if (this.flushTimer) {
       clearInterval(this.flushTimer);
       this.flushTimer = null;
     }
-    await this.flush();
+    await this.queue.flush();
   }
 
-  /**
-   * Update the access token (e.g. after a session refresh).
-   */
+  /** Update the access token (e.g. after a session refresh). */
   updateAccessToken(token: string): void {
     this.accessToken = token;
   }
 
-  /**
-   * Update the audit level from policy refresh.
-   */
+  /** Update the audit level from policy refresh. */
   updateAuditLevel(level: "full" | "metadata" | "off"): void {
-    this.auditLevel = level;
+    this.queue.setAuditLevel(level);
   }
 
-  /**
-   * Returns the current number of buffered events.
-   */
   get bufferSize(): number {
-    return this.buffer.length;
+    return this.queue.bufferSize;
   }
 
-  /**
-   * Returns the maximum buffer capacity.
-   */
   get bufferCapacity(): number {
-    return this.maxBufferSize;
+    return this.queue.bufferCapacity;
   }
 
-  /**
-   * Enqueue an audit event.
-   * If the buffer exceeds maxBufferSize, oldest events are dropped.
-   */
+  /** Enqueue an audit event. Triggers an automatic flush when the batch is full. */
   enqueue(params: AuditLoggerEnqueueParams): void {
-    if (this.auditLevel === "off") {
-      return;
-    }
-
-    const event: AuditEvent = {
-      userId: this.userId,
-      orgId: this.orgId,
+    const sizeBefore = this.queue.bufferSize;
+    this.queue.enqueue({
+      eventType: params.eventType,
+      outcome: params.outcome,
+      toolName: params.toolName,
       agentId: params.agentId,
       sessionKey: params.sessionKey,
-      eventType: params.eventType,
-      toolName: params.toolName,
-      timestamp: Date.now(),
-      outcome: params.outcome,
-      metadata: this.auditLevel === "full" ? params.metadata : undefined,
-    };
-
-    this.buffer.push(event);
-
-    // Enforce maximum buffer size by dropping oldest events.
-    if (this.buffer.length > this.maxBufferSize) {
-      const dropped = this.buffer.length - this.maxBufferSize;
-      this.buffer.splice(0, dropped);
-      this.logger?.warn(`Audit buffer exceeded max size (${this.maxBufferSize}). Dropped ${dropped} oldest event(s).`);
-    }
-
-    // Warn when approaching capacity (>80%).
-    const capacityRatio = this.buffer.length / this.maxBufferSize;
-    if (capacityRatio > BUFFER_WARNING_THRESHOLD && !this.hasWarnedCapacity) {
-      this.hasWarnedCapacity = true;
-      this.logger?.warn(
-        `Audit buffer approaching capacity: ${this.buffer.length}/${this.maxBufferSize} (${Math.round(capacityRatio * 100)}%)`,
-      );
-    } else if (capacityRatio <= BUFFER_WARNING_THRESHOLD) {
-      // Reset the warning flag when buffer goes back below threshold.
-      this.hasWarnedCapacity = false;
-    }
-
-    if (this.buffer.length >= this.batchSize) {
-      this.flush().catch((err) => {
-        this.logger?.warn(`Audit flush failed: ${String(err)}`);
-      });
+      metadata: params.metadata,
+    });
+    // Preserve the legacy "auto-flush on batch full" behavior. The queue
+    // exposes `shouldFlush()` for this — call it iff we just grew the buffer
+    // (auditLevel="off" no-ops, so size stays the same).
+    if (this.queue.bufferSize > sizeBefore && this.queue.shouldFlush()) {
+      void this.queue.flush().catch((err) => this.logger?.warn(`Audit flush failed: ${String(err)}`));
     }
   }
 
-  /**
-   * Flush buffered events to the control plane.
-   * Events are flushed in order (oldest first).
-   */
+  /** Flush buffered events to the control plane. */
   async flush(): Promise<void> {
-    if (this.buffer.length === 0) {
-      return;
-    }
-
-    const batch = this.buffer.splice(0);
-
-    if (!this.controlPlaneUrl) {
-      // No control plane configured; persist to disk.
-      this.persistBuffer(batch);
-      return;
-    }
-
-    try {
-      const url = `${this.controlPlaneUrl}/api/v1/audit/${encodeURIComponent(this.orgId)}/events`;
-      const response = await fetch(url, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${this.accessToken}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ events: batch }),
-      });
-
-      if (!response.ok) {
-        // Put events back and persist for retry.
-        this.logger?.warn(`Audit event submission failed (${response.status})`);
-        this.buffer.unshift(...batch);
-        this.enforceBufferLimit();
-        this.persistBuffer(this.buffer);
-      } else {
-        this.logger?.info(`Shipped ${batch.length} audit events`);
-        // Reset capacity warning after successful flush.
-        this.hasWarnedCapacity = false;
-        // Clear persisted buffer on success.
-        this.clearPersistedBuffer();
-      }
-    } catch (err) {
-      this.logger?.warn(`Audit event submission error: ${String(err)}`);
-      this.buffer.unshift(...batch);
-      this.enforceBufferLimit();
-      this.persistBuffer(this.buffer);
-    }
-  }
-
-  /**
-   * Enforce the buffer size limit, dropping oldest events if necessary.
-   */
-  private enforceBufferLimit(): void {
-    if (this.buffer.length > this.maxBufferSize) {
-      const dropped = this.buffer.length - this.maxBufferSize;
-      this.buffer.splice(0, dropped);
-      this.logger?.warn(
-        `Audit buffer trimmed: dropped ${dropped} oldest event(s) to stay within limit (${this.maxBufferSize}).`,
-      );
-    }
-  }
-
-  private persistBuffer(events: AuditEvent[]): void {
-    try {
-      fs.mkdirSync(CLAWFORGE_DIR, { recursive: true });
-      const lines = events.map((e) => JSON.stringify(e)).join("\n");
-      fs.writeFileSync(BUFFER_FILE, lines + "\n", { mode: 0o600 });
-    } catch {
-      // Best effort.
-    }
-  }
-
-  private clearPersistedBuffer(): void {
-    try {
-      fs.unlinkSync(BUFFER_FILE);
-    } catch {
-      // Ignore.
-    }
-  }
-
-  private loadPersistedBuffer(): void {
-    try {
-      const raw = fs.readFileSync(BUFFER_FILE, "utf-8");
-      const lines = raw.trim().split("\n").filter(Boolean);
-      for (const line of lines) {
-        try {
-          this.buffer.push(JSON.parse(line) as AuditEvent);
-        } catch {
-          // Skip malformed lines.
-        }
-      }
-      // Enforce limit on persisted buffer load too.
-      this.enforceBufferLimit();
-    } catch {
-      // No persisted buffer.
-    }
+    await this.queue.flush();
   }
 }

--- a/plugin/src/policy/tool-enforcer.ts
+++ b/plugin/src/policy/tool-enforcer.ts
@@ -1,12 +1,14 @@
 /**
  * Tool policy enforcer for ClawForge.
- * Implements the before_tool_call hook that blocks denied tools and enforces
- * org policy allow/deny lists and the kill switch.
  *
- * Supports offline mode overrides:
- * - 'allow' — Allow all tools when offline
- * - 'cached' — Use last cached policy even if stale
- * - undefined — Normal enforcement (or block-all when kill switch is active)
+ * Implements the OpenClaw `before_tool_call` hook. The actual decision logic
+ * lives in `@clawforgeai/policy-engine`; this file is the thin translation
+ * layer between OpenClaw's hook surface and the shared engine — it wires
+ * the engine's `PolicyDecision` to OpenClaw's `PluginHookBeforeToolCallResult`
+ * shape and emits the matching audit event via the existing AuditLogger.
+ *
+ * Behavior parity with the pre-extraction tool-enforcer is enforced by the
+ * existing plugin test suite (`tool-enforcer.test.ts`).
  */
 
 import type {
@@ -14,176 +16,11 @@ import type {
   PluginHookBeforeToolCallResult,
   PluginHookToolContext,
 } from "openclaw/plugin-sdk";
-import type { OrgPolicy, DlpScanResult } from "../types.js";
+import { evaluateToolCall } from "@clawforgeai/policy-engine";
+import type { PolicyDecision, PolicyEvaluationContext } from "@clawforgeai/policy-engine";
+import type { OrgPolicy } from "../types.js";
 import type { AuditLogger } from "../audit/audit-logger.js";
 import type { ConnectionStateManager } from "../connection/connection-state.js";
-import { scanToolArguments } from "../dlp/dlp-scanner.js";
-
-// Re-export for type usage in enforceDlp below
-type _DlpScanResultRef = DlpScanResult;
-
-/**
- * Normalize a tool name for comparison (lowercase, trim, resolve aliases).
- * Mirrors the normalizeToolName logic from src/agents/tool-policy.ts.
- */
-const TOOL_NAME_ALIASES: Record<string, string> = {
-  bash: "exec",
-  "apply-patch": "apply_patch",
-};
-
-function normalizeToolName(name: string): string {
-  const normalized = name.trim().toLowerCase();
-  return TOOL_NAME_ALIASES[normalized] ?? normalized;
-}
-
-/**
- * Well-known tool groups, mirroring src/agents/tool-policy.ts.
- */
-const TOOL_GROUPS: Record<string, string[]> = {
-  "group:memory": ["memory_search", "memory_get"],
-  "group:web": ["web_search", "web_fetch"],
-  "group:fs": ["read", "write", "edit", "apply_patch"],
-  "group:runtime": ["exec", "process"],
-  "group:sessions": [
-    "sessions_list",
-    "sessions_history",
-    "sessions_send",
-    "sessions_spawn",
-    "subagents",
-    "session_status",
-  ],
-  "group:ui": ["browser", "canvas"],
-  "group:media": ["image", "tts"],
-  "group:automation": ["cron", "gateway"],
-  "group:messaging": ["message"],
-  "group:agents": ["agents_list"],
-  "group:nodes": ["nodes"],
-};
-
-function expandGroups(list: string[]): Set<string> {
-  const expanded = new Set<string>();
-  for (const entry of list) {
-    const normalized = normalizeToolName(entry);
-    const group = TOOL_GROUPS[normalized];
-    if (group) {
-      for (const tool of group) {
-        expanded.add(tool);
-      }
-    } else {
-      expanded.add(normalized);
-    }
-  }
-  return expanded;
-}
-
-/**
- * Shell commands that perform filesystem read operations.
- * When group:fs is denied, exec calls using these commands are also blocked
- * to prevent bypassing filesystem restrictions via shell.
- */
-const FS_READ_COMMANDS = new Set([
-  "ls",
-  "cat",
-  "head",
-  "tail",
-  "less",
-  "more",
-  "find",
-  "locate",
-  "tree",
-  "stat",
-  "file",
-  "du",
-  "wc",
-  "od",
-  "xxd",
-  "hexdump",
-  "strings",
-  "readlink",
-  "realpath",
-  "basename",
-  "dirname",
-  "diff",
-  "cmp",
-  "md5sum",
-  "sha256sum",
-  "shasum",
-]);
-
-/**
- * Shell commands that perform filesystem write operations.
- * When group:fs is denied, exec calls using these commands are also blocked.
- */
-const FS_WRITE_COMMANDS = new Set([
-  "cp",
-  "mv",
-  "rm",
-  "mkdir",
-  "rmdir",
-  "touch",
-  "chmod",
-  "chown",
-  "chgrp",
-  "ln",
-  "install",
-  "mktemp",
-  "truncate",
-  "shred",
-  "tar",
-  "zip",
-  "unzip",
-  "gzip",
-  "gunzip",
-  "bzip2",
-]);
-
-/** All filesystem-related shell commands. */
-const FS_ALL_COMMANDS = new Set([...FS_READ_COMMANDS, ...FS_WRITE_COMMANDS]);
-
-/**
- * Extract the leading command name from a shell command string.
- * Handles env vars, sudo prefixes, and piped/chained commands.
- */
-function extractCommandNames(command: string): string[] {
-  const names: string[] = [];
-  // Split on pipes, &&, ||, and ; to get individual commands
-  const segments = command
-    .split(/[|;&]/)
-    .map((s) => s.trim())
-    .filter(Boolean);
-  for (const segment of segments) {
-    // Strip leading env vars (FOO=bar), sudo, env, etc.
-    const tokens = segment.split(/\s+/);
-    for (const token of tokens) {
-      if (token.includes("=") || token === "sudo" || token === "env" || token === "nohup") {
-        continue;
-      }
-      // Get just the binary name (strip path)
-      const bin = token.split("/").pop() ?? token;
-      if (bin) {
-        names.push(bin.toLowerCase());
-      }
-      break;
-    }
-  }
-  return names;
-}
-
-/**
- * Check if an exec call should be blocked because it uses filesystem commands
- * while group:fs is denied in the policy.
- */
-function isExecBlockedByFsDeny(denySet: Set<string>, params: Record<string, unknown>): boolean {
-  // Only apply if filesystem tools are denied (group:fs was expanded into these)
-  const fsToolsDenied = denySet.has("read") || denySet.has("write") || denySet.has("edit");
-  if (!fsToolsDenied) return false;
-
-  const command = (params.command ?? params.cmd ?? "") as string;
-  if (!command) return false;
-
-  const commandNames = extractCommandNames(command);
-  return commandNames.some((name) => FS_ALL_COMMANDS.has(name));
-}
 
 export type ToolEnforcerState = {
   policy: OrgPolicy | null;
@@ -206,191 +43,156 @@ export type ToolEnforcerState = {
 export function createToolEnforcerHook(
   state: ToolEnforcerState,
   auditLogger: Pick<AuditLogger, "enqueue">,
-  connectionStateManager?: ConnectionStateManager,
+  // Kept for backward compatibility; reserved for future connection-aware decisions.
+  _connectionStateManager?: ConnectionStateManager,
 ): (event: PluginHookBeforeToolCallEvent, ctx: PluginHookToolContext) => PluginHookBeforeToolCallResult | undefined {
   return (
     event: PluginHookBeforeToolCallEvent,
     ctx: PluginHookToolContext,
   ): PluginHookBeforeToolCallResult | undefined => {
-    const toolName = normalizeToolName(event.toolName);
+    const evalCtx: PolicyEvaluationContext = {
+      policy: state.policy,
+      killSwitchActive: state.killSwitchActive,
+      killSwitchMessage: state.killSwitchMessage,
+      offlineOverride: state.offlineOverride,
+      pendingInit: state.pendingInit,
+    };
 
-    // 0. Pending initialization — block by default (safe mode).
-    if (state.pendingInit && !state.policy) {
-      auditLogger.enqueue({
-        eventType: "tool_call_attempt",
-        toolName,
-        outcome: "blocked",
-        agentId: ctx.agentId,
-        sessionKey: ctx.sessionKey,
-        metadata: { reason: "pending_init" },
-      });
-      return {
-        block: true,
-        blockReason: "ClawForge: Plugin is still initializing. Please try again shortly.",
-      };
-    }
+    const decision = evaluateToolCall(evalCtx, {
+      rawToolName: event.toolName,
+      params: event.params,
+    });
 
-    // 1. Kill switch check — always takes precedence, even over offline overrides.
-    if (state.killSwitchActive) {
-      const reason = state.killSwitchMessage ?? "ClawForge: All tool calls blocked by organization kill switch";
-      auditLogger.enqueue({
-        eventType: "tool_call_attempt",
-        toolName,
-        outcome: "blocked",
-        agentId: ctx.agentId,
-        sessionKey: ctx.sessionKey,
-        metadata: { reason: "kill_switch" },
-      });
-      return { block: true, blockReason: reason };
-    }
-
-    // 2. Offline override modes.
-    if (state.offlineOverride === "allow") {
-      auditLogger.enqueue({
-        eventType: "tool_call_attempt",
-        toolName,
-        outcome: "allowed",
-        agentId: ctx.agentId,
-        sessionKey: ctx.sessionKey,
-        metadata: { reason: "offline_allow_mode" },
-      });
-      return undefined;
-    }
-
-    if (state.offlineOverride === "cached") {
-      return enforcePolicy(state.policy, toolName, event, ctx, auditLogger, "offline_cached_mode");
-    }
-
-    return enforcePolicy(state.policy, toolName, event, ctx, auditLogger);
+    return applyDecision(decision, event, ctx, auditLogger);
   };
 }
 
-/**
- * Enforce policy allow/deny lists on a tool call.
- */
-function enforcePolicy(
-  policy: OrgPolicy | null,
-  toolName: string,
+function applyDecision(
+  decision: PolicyDecision,
   event: PluginHookBeforeToolCallEvent,
   ctx: PluginHookToolContext,
   auditLogger: Pick<AuditLogger, "enqueue">,
-  modeReason?: string,
 ): PluginHookBeforeToolCallResult | undefined {
-  if (!policy) {
-    // No policy loaded - allow by default
+  const normalizedToolName = toAuditToolName(event.toolName, decision);
+  const reasonText = formatAuditReason(decision);
+
+  if (decision.reason === "dlp_block" || decision.reason === "dlp_violation_allowed") {
+    // DLP events get a dedicated event type so consumers can filter on them.
+    const dlp = decision.dlp;
+    if (!dlp) {
+      // Defensive — engine always populates `dlp` on DLP-tagged decisions.
+      return undefined;
+    }
+    const violationSummary = dlp.violations.map((v) => ({
+      rule: v.ruleName,
+      action: v.action,
+      severity: v.severity,
+      category: v.category,
+      redactedContext: v.redactedContext,
+    }));
     auditLogger.enqueue({
-      eventType: "tool_call_attempt",
-      toolName,
-      outcome: "allowed",
+      eventType: "dlp_violation",
+      toolName: normalizedToolName,
+      outcome: decision.outcome === "deny" ? "blocked" : "allowed",
       agentId: ctx.agentId,
       sessionKey: ctx.sessionKey,
-      metadata: { reason: modeReason ?? "no_policy" },
+      metadata: {
+        violations: violationSummary,
+        scannedFields: dlp.scannedFields,
+        effectiveAction: dlp.effectiveAction,
+      },
     });
+    if (decision.outcome === "deny" && decision.blockMessage) {
+      return { block: true, blockReason: decision.blockMessage };
+    }
     return undefined;
   }
 
-  // Deny list check
-  if (policy.tools.deny && policy.tools.deny.length > 0) {
-    const denySet = expandGroups(policy.tools.deny);
-    if (denySet.has(toolName)) {
-      auditLogger.enqueue({
-        eventType: "tool_call_attempt",
-        toolName,
-        outcome: "blocked",
-        agentId: ctx.agentId,
-        sessionKey: ctx.sessionKey,
-        metadata: { reason: modeReason ? `deny_list (${modeReason})` : "deny_list" },
-      });
-      return {
-        block: true,
-        blockReason: `ClawForge: Tool "${event.toolName}" is blocked by organization policy`,
-      };
-    }
+  const metadata = buildToolCallMetadata(decision, reasonText);
 
-    // When filesystem tools are denied, also block exec calls that run
-    // filesystem commands (ls, cat, find, etc.) to prevent policy bypass.
-    if (toolName === "exec" && isExecBlockedByFsDeny(denySet, event.params)) {
-      const command = (event.params.command ?? event.params.cmd ?? "") as string;
-      auditLogger.enqueue({
-        eventType: "tool_call_attempt",
-        toolName,
-        outcome: "blocked",
-        agentId: ctx.agentId,
-        sessionKey: ctx.sessionKey,
-        metadata: { reason: modeReason ? `fs_deny_exec (${modeReason})` : "fs_deny_exec", command },
-      });
-      return {
-        block: true,
-        blockReason: `ClawForge: Shell command blocked — filesystem access is denied by organization policy`,
-      };
-    }
-  }
-
-  // Allow list check
-  if (policy.tools.allow && policy.tools.allow.length > 0) {
-    const allowSet = expandGroups(policy.tools.allow);
-    if (!allowSet.has(toolName)) {
-      auditLogger.enqueue({
-        eventType: "tool_call_attempt",
-        toolName,
-        outcome: "blocked",
-        agentId: ctx.agentId,
-        sessionKey: ctx.sessionKey,
-        metadata: { reason: modeReason ? `not_in_allowlist (${modeReason})` : "not_in_allowlist" },
-      });
-      return {
-        block: true,
-        blockReason: `ClawForge: Tool "${event.toolName}" is not in the organization's allowed tools list`,
-      };
-    }
-  }
-
-  // DLP scan — check tool arguments for sensitive data patterns (#66)
-  if (policy.dlpRules && policy.dlpRules.length > 0) {
-    const dlpResult: _DlpScanResultRef = scanToolArguments(policy.dlpRules, event.params);
-
-    if (dlpResult.violations.length > 0) {
-      const violationSummary = dlpResult.violations.map((v) => ({
-        rule: v.ruleName,
-        action: v.action,
-        severity: v.severity,
-        category: v.category,
-        redactedContext: v.redactedContext,
-      }));
-
-      auditLogger.enqueue({
-        eventType: "dlp_violation",
-        toolName,
-        outcome: dlpResult.effectiveAction === "block" ? "blocked" : "allowed",
-        agentId: ctx.agentId,
-        sessionKey: ctx.sessionKey,
-        metadata: {
-          violations: violationSummary,
-          scannedFields: dlpResult.scannedFields,
-          effectiveAction: dlpResult.effectiveAction,
-        },
-      });
-
-      if (dlpResult.effectiveAction === "block") {
-        const blockingRules = dlpResult.violations.filter((v) => v.action === "block");
-        const ruleNames = blockingRules.map((v) => v.ruleName).join(", ");
-        return {
-          block: true,
-          blockReason: `ClawForge DLP: Tool call blocked — sensitive data detected (rules: ${ruleNames})`,
-        };
-      }
-    }
-  }
-
-  // Allowed
   auditLogger.enqueue({
     eventType: "tool_call_attempt",
-    toolName,
-    outcome: "allowed",
+    toolName: normalizedToolName,
+    outcome: decision.outcome === "deny" ? "blocked" : "allowed",
     agentId: ctx.agentId,
     sessionKey: ctx.sessionKey,
-    metadata: modeReason ? { reason: modeReason } : undefined,
+    metadata,
   });
 
+  if (decision.outcome === "deny" && decision.blockMessage) {
+    return { block: true, blockReason: decision.blockMessage };
+  }
   return undefined;
+}
+
+/**
+ * Build the `metadata` payload that older audit consumers expect on
+ * `tool_call_attempt` events. Specifically, the legacy enforcer used to
+ * pass `undefined` rather than `{ reason: undefined }` when the decision
+ * was a plain allow with no offline mode active — preserved here so the
+ * existing audit test assertions remain stable.
+ */
+function buildToolCallMetadata(
+  decision: PolicyDecision,
+  reasonText: string | undefined,
+): Record<string, unknown> | undefined {
+  // fs_deny_exec also reported the offending command in the legacy audit metadata.
+  if (decision.reason === "fs_deny_exec") {
+    return {
+      reason: reasonText,
+      command: decision.blockedCommand ?? "",
+    };
+  }
+
+  if (!reasonText) return undefined;
+  return { reason: reasonText };
+}
+
+/**
+ * Translate a PolicyDecision into the audit-reason string the legacy
+ * enforcer emitted. Same wording — same audit consumers keep working.
+ */
+function formatAuditReason(decision: PolicyDecision): string | undefined {
+  const suffix = decision.mode === "offline_cached_mode" ? " (offline_cached_mode)" : "";
+
+  switch (decision.reason) {
+    case "pending_init":
+      return "pending_init";
+    case "kill_switch":
+      return "kill_switch";
+    case "offline_allow_mode":
+      return "offline_allow_mode";
+    case "no_policy":
+      // Legacy quirk: in offline_cached mode + null policy, the reason
+      // emitted is the bare mode tag, not "no_policy (offline_cached_mode)".
+      return decision.mode === "offline_cached_mode" ? "offline_cached_mode" : "no_policy";
+    case "deny_list":
+      return `deny_list${suffix}`;
+    case "fs_deny_exec":
+      return `fs_deny_exec${suffix}`;
+    case "not_in_allowlist":
+      return `not_in_allowlist${suffix}`;
+    case "allowed":
+      return decision.mode === "offline_cached_mode" ? "offline_cached_mode" : undefined;
+    case "dlp_block":
+    case "dlp_violation_allowed":
+      // Handled by the DLP audit branch in applyDecision; never reaches here.
+      return undefined;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Audit events have historically logged the normalized tool name (e.g.
+ * "exec" instead of "bash"). The policy engine doesn't expose the
+ * normalized name on the decision, but we can recover it from the raw
+ * event name using the same normalization rule.
+ */
+function toAuditToolName(rawToolName: string, _decision: PolicyDecision): string {
+  // Match `normalizeToolName` semantics from @clawforgeai/tool-governance.
+  const normalized = rawToolName.trim().toLowerCase();
+  if (normalized === "bash") return "exec";
+  if (normalized === "apply-patch") return "apply_patch";
+  return normalized;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,6 +262,15 @@ importers:
 
   plugin:
     dependencies:
+      '@clawforgeai/audit-events':
+        specifier: workspace:*
+        version: link:../packages/audit-events
+      '@clawforgeai/contracts':
+        specifier: workspace:*
+        version: link:../packages/contracts
+      '@clawforgeai/policy-engine':
+        specifier: workspace:*
+        version: link:../packages/policy-engine
       '@clawforgeai/tool-governance':
         specifier: workspace:*
         version: link:../packages/tool-governance


### PR DESCRIPTION
## What changed

Refactors the OpenClaw plugin onto the shared platform packages **without behavior change**. All 163 existing plugin tests continue to pass.

### \`plugin/src/policy/tool-enforcer.ts\`
The OpenClaw \`before_tool_call\` hook is now a thin translation layer:
- calls \`@clawforgeai/policy-engine\` → \`evaluateToolCall()\`
- maps the returned \`PolicyDecision\` into OpenClaw \`PluginHookBeforeToolCallResult\` shape
- builds the legacy audit-metadata reason strings (\`deny_list\`, \`fs_deny_exec\`, \`not_in_allowlist (offline_cached_mode)\`, etc.) so existing audit consumers see no change

### \`plugin/src/audit/audit-logger.ts\`
Now a thin plugin-specific wrapper around \`BatchedAuditQueue\` from \`@clawforgeai/audit-events\`:
- the queue owns the bounded buffer, drop-oldest overflow, capacity warning, batch-size auto-flush
- the plugin keeps HTTP transport (\`POST /api/v1/audit/:orgId/events\`) and FS persistence (\`~/.openclaw/clawforge/audit-buffer.jsonl\`)
- public API is unchanged: \`enqueue/flush/start/stop/updateAccessToken/updateAuditLevel/bufferSize/bufferCapacity\`

## Phase 1 exit conditions

Per \`docs/technical-strategy.md\` §Phase 1 — now all satisfied:

- ✅ \`packages/contracts\` with policy/approval/heartbeat/audit/runtime schemas
- ✅ \`packages/policy-engine\` with shared evaluation
- ✅ \`packages/audit-events\` with normalized event writers
- ✅ \`packages/agent-sdk\` with adapter lifecycle helpers
- ✅ \`packages/auth\` with shared identity models
- ✅ \`packages/tool-governance\` with action taxonomy / MCP / DLP
- ✅ Plugin refactored to consume shared packages while preserving behavior

The repo is ready to add a second runtime adapter (Claude Code, Phase 2 #148) without duplicating schema or decision logic.

## How to test

- [x] \`pnpm --filter @clawforgeai/clawforge test\` — **163/163 plugin tests pass** (behavior parity contract)
- [x] \`pnpm -r --filter './packages/*' build && test && typecheck\` — clean
- [x] \`pnpm --filter @ClawForgeAI/clawforge-server build && test\` — 195/195 pass
- [x] \`pnpm --filter @ClawForgeAI/clawforge-admin build\` — clean
- [x] \`pnpm format:check\` / \`pnpm lint\` / \`pnpm check:deps\` — clean

## Out of scope (follow-ups)

- Wiring \`server/\` and \`admin/\` to import directly from \`@clawforgeai/contracts\` for schema-level validation. The plugin extraction was the load-bearing piece; server/admin can adopt the contracts package iteratively without blocking Phase 1.

## Checklist

- [x] No public API changes — \`AuditLogger\` and \`createToolEnforcerHook\` signatures unchanged
- [x] Behavior parity verified by existing plugin test suite