### PR TITLE
fix(admin): pin daisyui back to ^4.12.24

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -12,7 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "daisyui": "^5.5.19",
+    "daisyui": "^4.12.24",
     "framer-motion": "^12.38.0",
     "next": "^16.2.6",
     "react": "^19.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
   admin:
     dependencies:
       daisyui:
-        specifier: ^5.5.19
-        version: 5.5.19
+        specifier: ^4.12.24
+        version: 4.12.24(postcss@8.5.13)
       framer-motion:
         specifier: ^12.38.0
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -3604,6 +3604,9 @@ packages:
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
+  css-selector-tokenizer@0.8.0:
+    resolution: {integrity: sha512-Jd6Ig3/pe62/qe5SBPTN8h8LeUg/pT4lLgtavPf7updwwHpvFzxvOQBHYj2LZDMjUnBzgvIUSjRcf6oT5HzHFg==}
+
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
@@ -3626,11 +3629,16 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  culori@3.3.0:
+    resolution: {integrity: sha512-pHJg+jbuFsCjz9iclQBqyL3B2HLCBF71BwVNujUYEvCeQMvV97R59MNK3R2+jgJ3a1fcZgI9B3vYgz8lzr/BFQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   curve25519-js@0.0.4:
     resolution: {integrity: sha512-axn2UMEnkhyDUPWOwVKBMVIzSQy2ejH2xRGy1wq81dqRwApXfIzfbE3hIX0ZRFBIihf/KDqK158DLwESu4AK1w==}
 
-  daisyui@5.5.19:
-    resolution: {integrity: sha512-pbFAkl1VCEh/MPCeclKL61I/MqRIFFhNU7yiXoDDRapXN4/qNCoMxeCCswyxEEhqL5eiTTfwHvucFtOE71C9sA==}
+  daisyui@4.12.24:
+    resolution: {integrity: sha512-JYg9fhQHOfXyLadrBrEqCDM6D5dWCSSiM6eTNCRrBRzx/VlOCrLS8eDfIw9RVvs64v2mJdLooKXY8EwQzoszAA==}
+    engines: {node: '>=16.9.0'}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -4084,6 +4092,9 @@ packages:
 
   fastparallel@2.4.1:
     resolution: {integrity: sha512-qUmhxPgNHmvRjZKBFUNI0oZuuH9OlSIOXmJ98lhKPxMZZ7zS/Fi0wRHOihDSz0R1YiIOjxzOY4bq65YTcdBi2Q==}
+
+  fastparse@1.1.2:
+    resolution: {integrity: sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -9816,6 +9827,11 @@ snapshots:
       domutils: 3.2.2
       nth-check: 2.1.1
 
+  css-selector-tokenizer@0.8.0:
+    dependencies:
+      cssesc: 3.0.0
+      fastparse: 1.1.2
+
   css-tree@3.2.1:
     dependencies:
       mdn-data: 2.27.1
@@ -9831,9 +9847,18 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  culori@3.3.0: {}
+
   curve25519-js@0.0.4: {}
 
-  daisyui@5.5.19: {}
+  daisyui@4.12.24(postcss@8.5.13):
+    dependencies:
+      css-selector-tokenizer: 0.8.0
+      culori: 3.3.0
+      picocolors: 1.1.1
+      postcss-js: 4.1.0(postcss@8.5.13)
+    transitivePeerDependencies:
+      - postcss
 
   data-uri-to-buffer@4.0.1: {}
 
@@ -10345,6 +10370,8 @@ snapshots:
     dependencies:
       reusify: 1.1.0
       xtend: 4.0.2
+
+  fastparse@1.1.2: {}
 
   fastq@1.20.1:
     dependencies:


### PR DESCRIPTION
## What changed

Pins \`daisyui\` back to \`^4.12.24\` in \`admin/package.json\` and regenerates \`pnpm-lock.yaml\`.

## Why

**PR #228** (production-dependencies group of 5 updates) bundled a major **daisyui v4 → v5 bump** alongside otherwise-safe patches (zod 4.4.2→4.4.3, next 16.2.4→16.2.6, react/react-dom 19.2.5→19.2.6). I missed the major-version bump hidden inside the group title and merged it earlier today — apologies.

The same daisyui v5 bump was previously merged as **#113 and immediately reverted in \`a798a49\`** because the admin uses many v4-only utility classes that render wrong under v5:

- 72+ usages of \`form-control\`, \`input-bordered\`, \`btn-group\` and related classes (these are deprecated/removed in v5)
- daisyui v5 also revamps the theme system, which would need a coordinated migration

The other 4 patches from #228 stay on main — only daisyui is pinned back.

## How to test

- [x] \`pnpm install --frozen-lockfile\` — clean
- [x] \`pnpm --filter @ClawForgeAI/clawforge-admin build\` — clean (Next.js compiles)
- [x] \`pnpm --filter @ClawForgeAI/clawforge-server build && test\` — 195/195 pass
- [x] \`pnpm --filter @clawforgeai/clawforge test\` — 163/163 pass
- [x] \`pnpm -r --filter './packages/*' build && test\` — clean
- [x] \`pnpm lint\` — 0 errors
- [x] \`pnpm format:check\` — clean

## Follow-up

To prevent grouped PRs from re-introducing this, consider adding a \`.github/dependabot.yml\` ignore entry:

\`\`\`yaml
ignore:
  - dependency-name: "daisyui"
    update-types: ["version-update:semver-major"]
  - dependency-name: "tailwindcss"
    update-types: ["version-update:semver-major"]
  - dependency-name: "@types/node"
    update-types: ["version-update:semver-major"]
\`\`\`

(Not included in this PR — happy to follow up in a separate change if you want.)

## Checklist

- [x] No code changes outside \`admin/package.json\` + \`pnpm-lock.yaml\`
- [x] All other patches from #228 preserved